### PR TITLE
Serve multiple files

### DIFF
--- a/grip/server.py
+++ b/grip/server.py
@@ -40,13 +40,13 @@ def serve(path=None, host=None, port=None, gfm=False, context=None):
     # Views
     @app.route('/')
     def index():
-        return render_page(_read_file(index_file), os.path.split(path)[1], gfm, context, app.config['STYLE_URLS'])
+        return render_page(_read_file(index_file), os.path.split(index_file)[1], gfm, context, app.config['STYLE_URLS'])
 
     @app.route('/<path:filename>')
     def other_files(filename):
         try:
             full_file = safe_join(path, filename)
-            return render_page(_read_file(full_file), os.path.split(path)[1], gfm, context, app.config['STYLE_URLS'])
+            return render_page(_read_file(full_file), os.path.split(filename)[1], gfm, context, app.config['STYLE_URLS'])
         except:
             abort(404)
 


### PR DESCRIPTION
I propose we change the code to be able to serve not only README.md files, but also files which are linked from README.md. To do that I propose we open the files which are passed through the URL, by safe_join-ing with the initial root path of the repository we are serving. This way we can both render all the documentation, not only README.md and serve other files which are in the folder.

I made a pull request for this issue, which you can review and add to your repository if you find it useful.
