### PR TITLE
Add --user/--pass options to supply GitHub credentials

### DIFF
--- a/grip/command.py
+++ b/grip/command.py
@@ -18,6 +18,8 @@ Options:
   --gfm             Use GitHub-Flavored Markdown, e.g. comments or issues
   --context=<repo>  The repository context, only taken into account with --gfm
   --render-offline  Render offline instead of via GitHub markdown API
+  --user=<username> A GitHub username for API authentication
+  --pass=<password> A GitHub password for API authentication
 """
 
 import sys
@@ -50,7 +52,7 @@ def main(argv=None):
     # Run server
     try:
         serve(path, host, port, args['--gfm'], args['--context'],
-              args['--render-offline'])
+              args['--render-offline'], args['--user'], args['--pass'])
         return 0
     except ValueError, ex:
         print 'Error:', ex

--- a/grip/github_renderer.py
+++ b/grip/github_renderer.py
@@ -9,7 +9,7 @@ except ImportError:
     except ImportError:
         pass
 
-def render_content(text, gfm=False, context=None):
+def render_content(text, gfm=False, context=None, username=None, password=None):
     """Renders the specified markup."""
     if gfm:
         url = 'https://api.github.com/markdown'
@@ -21,5 +21,8 @@ def render_content(text, gfm=False, context=None):
         url = 'https://api.github.com/markdown/raw'
         data = text
     headers = {'content-type': 'text/plain'}
-    r = requests.post(url, headers=headers, data=data)
+    if username:
+        r = requests.post(url, headers=headers, data=data, auth=(username, password))
+    else:
+        r = requests.post(url, headers=headers, data=data)
     return r.text

--- a/grip/renderer.py
+++ b/grip/renderer.py
@@ -6,13 +6,13 @@ from .offline_renderer import render_content as offline_render
 env = Environment(loader=PackageLoader('grip', 'templates'))
 index_template = env.get_template('index.html')
 
-def render_content(text, gfm=False, context=None, render_offline=False):
+def render_content(text, gfm=False, context=None, render_offline=False, username=None, password=None):
     if render_offline:
         return offline_render(text, gfm, context)
-    return github_render(text, gfm, context)
+    return github_render(text, gfm, context, username, password)
 
 def render_page(text, filename=None, gfm=False, context=None,
-                render_offline=False, style_urls=[]):
+                render_offline=False, username=None, password=None, style_urls=[]):
     """Renders the specified markup text to an HTML page."""
-    content = render_content(text, gfm, context, render_offline)
+    content = render_content(text, gfm, context, render_offline, username, password)
     return index_template.render(content=content, filename=filename, style_urls=style_urls)

--- a/grip/server.py
+++ b/grip/server.py
@@ -10,7 +10,7 @@ default_filenames = ['README.md', 'README.markdown']
 
 
 def serve(path=None, host=None, port=None, gfm=False, context=None,
-          render_offline=False):
+          render_offline=False, username=None, password=None):
     """Starts a server to render the specified file or directory containing a README."""
     if not path or os.path.isdir(path):
         path = _find_file(path)
@@ -60,7 +60,7 @@ def serve(path=None, host=None, port=None, gfm=False, context=None,
         else:
             text = _read_file(path)
         return render_page(text, filename, gfm, context, render_offline,
-                           app.config['STYLE_URLS'])
+                           username, password, app.config['STYLE_URLS'])
 
     # Run local server
     app.run(app.config['HOST'], app.config['PORT'], debug=app.debug, use_reloader=app.config['DEBUG_GRIP'])


### PR DESCRIPTION
Allows users to make authenticated requests to the GitHub API, upping
their render limit from 60 requests per hour to 5000 requests per hour.

Closes #15 and fixes #18.
