### PR TITLE
fix manual installs using setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,8 @@ setup(
     license='MIT',
     platforms='any',
     packages=find_packages(),
+    data_files=[('grip/templates', ['grip/templates/base.html',
+                                    'grip/templates/index.html'])],
     install_requires=read('requirements.txt'),
     zip_safe=False,
     entry_points={'console_scripts': ['grip = grip.command:main']},


### PR DESCRIPTION
Installing from source wasn't copying the html templates:

```
$ mkvirtualenv grip
$ workon grip
(grip)$ python setup.py install
(grip)$ grip
Traceback (most recent call last):
  File "/home/brian/.virtualenvs/grip/bin/grip", line 9, in <module>
    load_entry_point('grip==1.2.0', 'console_scripts', 'grip')()
  File "/home/brian/.virtualenvs/grip/local/lib/python2.7/site-packages/distribute-0.6.34-py2.7.egg/pkg_resources.py", line 343, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/home/brian/.virtualenvs/grip/local/lib/python2.7/site-packages/distribute-0.6.34-py2.7.egg/pkg_resources.py", line 2307, in load_entry_point
    return ep.load()
  File "/home/brian/.virtualenvs/grip/local/lib/python2.7/site-packages/distribute-0.6.34-py2.7.egg/pkg_resources.py", line 2013, in load
    entry = __import__(self.module_name, globals(),globals(), ['__name__'])
  File "/home/brian/.virtualenvs/grip/local/lib/python2.7/site-packages/grip-1.2.0-py2.7.egg/grip/__init__.py", line 14, in <module>
    from . import command
  File "/home/brian/.virtualenvs/grip/local/lib/python2.7/site-packages/grip-1.2.0-py2.7.egg/grip/command.py", line 28, in <module>
    from .server import serve
  File "/home/brian/.virtualenvs/grip/local/lib/python2.7/site-packages/grip-1.2.0-py2.7.egg/grip/server.py", line 6, in <module>
    from .renderer import render_page
  File "/home/brian/.virtualenvs/grip/local/lib/python2.7/site-packages/grip-1.2.0-py2.7.egg/grip/renderer.py", line 7, in <module>
    index_template = env.get_template('index.html')
  File "/home/brian/.virtualenvs/grip/local/lib/python2.7/site-packages/Jinja2-2.6-py2.7.egg/jinja2/environment.py", line 719, in get_template
    return self._load_template(name, self.make_globals(globals))
  File "/home/brian/.virtualenvs/grip/local/lib/python2.7/site-packages/Jinja2-2.6-py2.7.egg/jinja2/environment.py", line 693, in _load_template
    template = self.loader.load(self, name, globals)
  File "/home/brian/.virtualenvs/grip/local/lib/python2.7/site-packages/Jinja2-2.6-py2.7.egg/jinja2/loaders.py", line 115, in load
    source, filename, uptodate = self.get_source(environment, name)
  File "/home/brian/.virtualenvs/grip/local/lib/python2.7/site-packages/Jinja2-2.6-py2.7.egg/jinja2/loaders.py", line 227, in get_source
    raise TemplateNotFound(template)
jinja2.exceptions.TemplateNotFound: index.html
```
