### PR TITLE
Add support for rendering images.

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -6,5 +6,6 @@ along with the following contributors:
 
 - Vlad Wing ([@vladwing](https://github.com/vladwing))
 - Ismail Badawi ([@isbadawi](https://github.com/isbadawi))
+- John Gallagher ([@jgallagher](https://github.com/jgallagher))
 
 [home]: README.md

--- a/grip/renderer.py
+++ b/grip/renderer.py
@@ -1,6 +1,7 @@
 from jinja2 import Environment, PackageLoader
 from .github_renderer import render_content as github_render
 from .offline_renderer import render_content as offline_render
+from flask import make_response
 
 
 # Get jinja templates
@@ -22,3 +23,9 @@ def render_page(text, filename=None, gfm=False, context=None, render_offline=Fal
     content = render_content(text, gfm, context, render_offline, username, password)
     return index_template.render(content=content, filename=filename,
                                  style_urls=style_urls)
+
+def render_image(image_data, content_type):
+    """Renders the specified image data with the given Content-Type."""
+    response = make_response(image_data)
+    response.headers['Content-Type'] = content_type
+    return response

--- a/grip/server.py
+++ b/grip/server.py
@@ -2,9 +2,10 @@ import os
 import re
 import errno
 import requests
+import mimetypes
 from traceback import format_exc
 from flask import Flask, current_app, safe_join, abort, url_for, send_from_directory
-from .renderer import render_page
+from .renderer import render_page, render_image
 
 
 default_filenames = ['README.md', 'README.markdown']
@@ -70,6 +71,12 @@ def serve(path=None, host=None, port=None, gfm=False, context=None,
                 if ex.errno != errno.ENOENT:
                     raise
                 return abort(404)
+
+            # if we think this file is an image, serve it as such
+            mimetype, _ = mimetypes.guess_type(filename)
+            if mimetype.startswith("image/"):
+                return render_image(text, mimetype)
+
             filename_display = _display_filename(filename)
         else:
             text = _read_file(path)


### PR DESCRIPTION
This pull request adds support for rendering images that have relative paths, a la [Relative links in READMEs](https://help.github.com/articles/relative-links-in-readmes):

``` markdown
![some text](./path/to/foo.png)
```
