### PR TITLE
Fix #38

### DIFF
--- a/grip/server.py
+++ b/grip/server.py
@@ -22,7 +22,7 @@ def create_app(path=None, gfm=False, context=None, username=None, password=None,
         raise ValueError('File not found: ' + path)
 
     # Flask application
-    app = Flask(__name__, instance_path=os.abspath(os.path.expanduser("~/.grip")))
+    app = Flask(__name__, instance_path=os.path.abspath(os.path.expanduser("~/.grip")))
     app.config.from_pyfile('settings.py')
     app.config.from_pyfile('settings_local.py', silent=True)
     app.config['GRIP_FILE'] = os.path.normpath(path)


### PR DESCRIPTION
Explicitly set the instance_path parameter to Flask so that when the app is installed, it doesn't try to write to a privileged directory.
