### PR TITLE
Added options for offline rendering and encoding.

### DIFF
--- a/grip/__init__.py
+++ b/grip/__init__.py
@@ -8,7 +8,7 @@ Render local readme files before sending off to Github.
 :license: MIT, see LICENSE for more details.
 """
 
-__version__ = '2.0.0'
+__version__ = '2.0.1'
 
 
 from . import command

--- a/grip/command.py
+++ b/grip/command.py
@@ -15,11 +15,13 @@ Where:
   <address> is what to listen on, of the form <host>[:<port>], or just <port>
 
 Options:
-  --gfm             Use GitHub-Flavored Markdown, e.g. comments or issues
-  --context=<repo>  The repository context, only taken into account with --gfm
-  --user=<username> A GitHub username for API authentication
-  --pass=<password> A GitHub password for API authentication
-  --export          Exports to <path>.html or README.md instead of serving
+  --gfm                 Use GitHub-Flavored Markdown, e.g. comments or issues
+  --context=<repo>      The repository context, only taken into account with --gfm
+  --user=<username>     A GitHub username for API authentication
+  --pass=<password>     A GitHub password for API authentication
+  --export              Exports to <path>.html or README.md instead of serving
+  --offline             Uses the offline renderer.
+  --encoding=<utf-8>    Sets the encoding for files read in. Ignored without --offline.
 """
 
 import sys
@@ -41,6 +43,11 @@ def main(argv=None):
 
     # Parse options
     args = docopt(usage, argv=argv, version=version)
+    if not args['--offline']:
+        args['--encoding'] = 'ascii'
+    elif not args['--encoding']:
+        args['--encoding'] = 'utf-8'
+    print( args )
 
     # Parse arguments
     path, address = resolve(args['<path>'], args['<address>'])
@@ -50,7 +57,7 @@ def main(argv=None):
     if args['--export']:
         try:
             export(path, args['--gfm'], args['--context'],
-                  args['--user'], args['--pass'], False)
+                  args['--user'], args['--pass'], args['--offline'] )
             return 0
         except ValueError as ex:
             print 'Error:', ex
@@ -63,7 +70,7 @@ def main(argv=None):
     # Run server
     try:
         serve(path, host, port, args['--gfm'], args['--context'],
-              args['--user'], args['--pass'], False)
+              args['--user'], args['--pass'], args['--offline'] )
         return 0
     except ValueError as ex:
         print 'Error:', ex

--- a/grip/offline_renderer.py
+++ b/grip/offline_renderer.py
@@ -5,7 +5,7 @@ from mdx_urlize import UrlizeExtension
 def render_content(text, gfm=False, context=None):
     """Renders the specified markup locally."""
     return markdown.markdown(text, extensions=[
-        'fenced_code', 
+        'fenced_code',
         'codehilite(css_class=highlight)',
         UrlizeExtension(),
     ])

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ def read(fname):
 
 setup(
     name='grip',
-    version='2.0.0',
+    version='2.0.1',
     description='Render local readme files before sending off to Github.',
     long_description=__doc__,
     author='Joe Esposito',


### PR DESCRIPTION
- Added an option "--offline" to access the offline Markdown render
  routine.
- Added an option "--encoding" to specify input file encoding (the
  Markdown package wants a unicode string). Default encoding is utf-8.
