### PR TITLE
Add sane default instance dir, make configurable

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -10,5 +10,6 @@ along with the following contributors:
 - Brian Cappello ([@briancappello](https://github.com/briancappello))
 - John Gallagher ([@jgallagher](https://github.com/jgallagher))
 - Ilya Rumyantsev ([@iliggio](https://github.com/iliggio))
+- Jacobo de Vera ([@jdevera](https://github.com/jdevera))
 
 [home]: README.md

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Runs a local server and renders the Readme file located
 at `path` when visited in the browser.
 
 ```python
-serve(path='file-or-directory', host='localhost', port=5000, gfm=False, context=None, username=None, password=None, render_offline=False)
+serve(path='file-or-directory', host='localhost', port=5000, gfm=False, context=None, username=None, password=None, app_dir=None, render_offline=False)
 ```
 
 - `path`: The filename to render, or the directory containing your Readme file
@@ -118,6 +118,7 @@ serve(path='file-or-directory', host='localhost', port=5000, gfm=False, context=
              takes the form of `username/project`
 - `username`: The user to authenticate with GitHub to extend the API limit
 - `password`: The password to authenticate with GitHub to extend the API limit
+- `app_dir`: The directory to hold the Flask app instance
 - `render_offline`: Whether to render locally using [Python-Markdown][] (Note: this is a work in progress)
 
 
@@ -146,7 +147,7 @@ This is the same app used by `serve` and `export` and initializes the cache,
 using the cached styles when available.
 
 ```python
-create_app(path='file-or-directory', gfm=False, context=None, username=None, password=None, render_offline=False, render_inline=False)
+create_app(path='file-or-directory', gfm=False, context=None, username=None, password=None, app_dir=None, render_offline=False, render_inline=False)
 ```
 
 - `path`: The filename to render, or the directory containing your Readme file
@@ -155,6 +156,7 @@ create_app(path='file-or-directory', gfm=False, context=None, username=None, pas
              takes the form of `username/project`
 - `username`: The user to authenticate with GitHub to extend the API limit
 - `password`: The password to authenticate with GitHub to extend the API limit
+- `app_dir`: The directory to hold the Flask app instance
 - `render_offline`: Whether to render locally using [Python-Markdown][] (Note: this is a work in progress)
 - `render_inline`: Whether to inline the styles within the HTML file
 

--- a/grip/command.py
+++ b/grip/command.py
@@ -19,6 +19,7 @@ Options:
   --context=<repo>  The repository context, only taken into account with --gfm
   --user=<username> A GitHub username for API authentication
   --pass=<password> A GitHub password for API authentication
+  --app-dir=<dir>   The path to the app instance (holds cached styles)
   --export          Exports to <path>.html or README.md instead of serving
 """
 
@@ -63,7 +64,7 @@ def main(argv=None):
     # Run server
     try:
         serve(path, host, port, args['--gfm'], args['--context'],
-              args['--user'], args['--pass'], False)
+              args['--user'], args['--pass'], args['--app-dir'], False)
         return 0
     except ValueError as ex:
         print 'Error:', ex

--- a/grip/server.py
+++ b/grip/server.py
@@ -13,7 +13,7 @@ default_filenames = ['README.md', 'README.markdown']
 
 
 def create_app(path=None, gfm=False, context=None, username=None, password=None,
-               render_offline=False, render_inline=False):
+               app_dir=None, render_offline=False, render_inline=False):
     """Starts a server to render the specified file or directory containing a README."""
     if not path or os.path.isdir(path):
         path = _find_file(path)
@@ -21,8 +21,13 @@ def create_app(path=None, gfm=False, context=None, username=None, password=None,
     if not os.path.exists(path):
         raise ValueError('File not found: ' + path)
 
+    if app_dir is not None:
+        instance_path = os.path.abspath(app_dir)
+    else:
+        instance_path = os.path.expanduser("~/.cache/grip")
+
     # Flask application
-    app = Flask(__name__)
+    app = Flask(__name__, instance_path=instance_path)
     app.config.from_pyfile('settings.py')
     app.config.from_pyfile('settings_local.py', silent=True)
     app.config['GRIP_FILE'] = os.path.normpath(path)
@@ -97,9 +102,9 @@ def create_app(path=None, gfm=False, context=None, username=None, password=None,
 
 
 def serve(path=None, host=None, port=None, gfm=False, context=None,
-          username=None, password=None, render_offline=False):
+          username=None, password=None, app_dir=None, render_offline=False):
     """Starts a server to render the specified file or directory containing a README."""
-    app = create_app(path, gfm, context, username, password, render_offline)
+    app = create_app(path, gfm, context, username, password, app_dir, render_offline)
 
     # Set overridden config values
     if host is not None:


### PR DESCRIPTION
Use a non privileged directory for the app instance. Use ~/.cache/grip
by default but allow the user to specify an alternative directory with
the --app-dir option.

Fixes #38
