### PR TITLE
Update dependency to requests.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 path-and-address==0.2.0
-requests==1.2.3
+requests==2.2
 docopt==0.6.1
 Jinja2==2.7.1
 Flask==0.10.1


### PR DESCRIPTION
Now a more recent version (2.2.x) of the requests HTTP-library will
be used, so that it doesn't force other packages in the (virtual-)
environment to use the old version (1.2.3) also.
