### PR TITLE
Support newer versions of dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,6 @@
 Flask==0.10.1
-Jinja2==2.7.3
 Markdown==2.4.1
-MarkupSafe==0.23
 Pygments==1.6
-Werkzeug==0.9.6
 docopt==0.6.2
-itsdangerous==0.24
 path-and-address==1.0.0
 requests==2.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-Flask==0.10.1
-Markdown==2.4.1
-Pygments==1.6
-docopt==0.6.2
-path-and-address==1.0.0
-requests==2.3.0
+Flask>=0.10.1
+Markdown>=2.4.1
+Pygments>=1.6
+docopt>=0.6.2
+path-and-address>=1.0.0
+requests>=2.3.0


### PR DESCRIPTION
Newer versions of dependencies could also be supported. This would allow better integration with distribution native package managers as they normally only install the newest appropriate version. I have it running fine on Arch Linux with  requests 2.4.3 and markdown 2.5.

While at it, transitive dependencies could also be removed to clean up. Flask already pulls in itsdangerous, Werkzeug and Jinja, which in turn requires markupsafe.
