### PR TITLE
Introduce environment variable GRIPHOME for greater customizability of instance_path

### DIFF
--- a/grip/server.py
+++ b/grip/server.py
@@ -204,7 +204,10 @@ def resolve_readme(path=None, force=False):
 
 
 def _create_flask():
-    instance_path = os.path.abspath(os.path.expanduser('~/.grip'))
+    if 'GRIPHOME' in os.environ:
+        instance_path = os.environ['GRIPHOME']
+    else:
+        instance_path = os.path.abspath(os.path.expanduser('~/.grip'))
     user_settings = os.path.join(instance_path, 'settings.py')
     default_static_url_path = '/grip-static'
 


### PR DESCRIPTION
I would like to declutter my home directory and put grip's config file `settings.py` in `~/.config/grip/settings.py` (per [XDG Base Directory Specification](http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html)) for easier versioning, but this is currently impossible, unless I missed something.

In this PR, I use the environment variable `GRIPHOME` as `instance_path` if set, and fall
back to the default `~/.grip` otherwise. This way I can set `GRIPHOME` to `~/.config/grip` to my liking, and others could set it to something else that they prefer.