### PR TITLE
Allow alternative github API URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ To customize Grip, create `~/.grip/settings.py`, then add one or more of the fol
 - `DEBUG_GRIP`: Prints extended information when an error happens, `False` by default
 - `USERNAME`: The username to use when not provided as a CLI argument, `None` by default
 - `PASSWORD`: The password or [personal access token][] to use when not provided as a CLI argument (*Please don't save your passwords here.* Instead, use an access token or drop in this code [grab your password from a password manager][keychain-access]), `None` by default
+- `API_URL`: Base URL for the github API, for example that of a Github Enterprise instance. The default is the public API https://api.github.com.
 - `CACHE_DIRECTORY`: The directory, relative to `~/.grip`, to place cached assets (this gets run through the following filter: `CACHE_DIRECTORY.format(version=__version__)`), `'cache-{version}'` by default
 - `CACHE_URL`: The URL to serve cached styles and assets from, in case there's a URL conflict, `'/grip-cache'` by default
 - `STATIC_URL_PATH`: The URL to serve static assets from, in case there's a URL conflict, `'/grip-static'` by default
@@ -238,7 +239,7 @@ Runs a local server and renders the Readme file located
 at `path` when visited in the browser.
 
 ```python
-serve(path=None, host=None, port=None, gfm=False, context=None, username=None, password=None, render_offline=False, render_wide=False, render_inline=False)
+serve(path=None, host=None, port=None, gfm=False, context=None, username=None, password=None, render_offline=False, render_wide=False, render_inline=False, api_url=None)
 ```
 
 - `path`: The filename to render, or the directory containing your Readme file, defaulting to the current working directory
@@ -249,6 +250,7 @@ serve(path=None, host=None, port=None, gfm=False, context=None, username=None, p
              takes the form of `username/project`
 - `username`: The user to authenticate with GitHub to extend the API limit
 - `password`: The password to authenticate with GitHub to extend the API limit
+- `api_url`: A different base URL for the github API, for example that of a Github Enterprise instance. The default is the public API https://api.github.com.
 - `render_offline`: Whether to render locally using [Python-Markdown][] (Note: this is a work in progress)
 - `render_wide`: Whether to render a wide page, `False` by default (this has no effect when used with `gfm`)
 - `render_inline`: Whether to inline the styles within the HTML file
@@ -259,7 +261,7 @@ serve(path=None, host=None, port=None, gfm=False, context=None, username=None, p
 Writes the specified Readme file to an HTML file with styles and assets inlined.
 
 ```python
-export(path=None, gfm=False, context=None, username=None, password=None, render_offline=False, render_wide=False, render_inline=True, out_filename=None)
+export(path=None, gfm=False, context=None, username=None, password=None, render_offline=False, render_wide=False, render_inline=True, out_filename=None, api_url=None)
 ```
 
 - `path`: The filename to render, or the directory containing your Readme file, defaulting to the current working directory
@@ -268,6 +270,7 @@ export(path=None, gfm=False, context=None, username=None, password=None, render_
              takes the form of `username/project`
 - `username`: The user to authenticate with GitHub to extend the API limit
 - `password`: The password to authenticate with GitHub to extend the API limit
+- `api_url`: A different base URL for the github API, for example that of a Github Enterprise instance. The default is the public API https://api.github.com.
 - `render_offline`: Whether to render locally using [Python-Markdown][] (Note: this is a work in progress)
 - `render_wide`: Whether to render a wide page, `False` by default (this has no effect when used with `gfm`)
 - `render_inline`: Whether to inline the styles within the HTML file (Note: unlike the other API functions, this defaults to `True`)
@@ -281,7 +284,7 @@ This is the same app used by `serve` and `export` and initializes the cache,
 using the cached styles when available.
 
 ```python
-create_app(path=None, gfm=False, context=None, username=None, api_url=None, render_offline=False, render_wide=False, render_inline=False, text=None, password=None)
+create_app(path=None, gfm=False, context=None, username=None, render_offline=False, render_wide=False, render_inline=False, text=None, password=None, api_url=None)
 ```
 
 - `path`: The filename to render, or the directory containing your Readme file, defaulting to the current working directory
@@ -315,7 +318,7 @@ render_app(app, route='/')
 Renders the specified markdown text without caching.
 
 ```python
-render_content(text, gfm=False, context=None, username=None, password=None, render_offline=False)
+render_content(text, gfm=False, context=None, username=None, password=None, render_offline=False, api_url=None)
 ```
 
 - `text`: The Markdown text to render
@@ -324,6 +327,7 @@ render_content(text, gfm=False, context=None, username=None, password=None, rend
              takes the form of `username/project`
 - `username`: The user to authenticate with GitHub to extend the API limit
 - `password`: The password to authenticate with GitHub to extend the API limit
+- `api_url`: A different base URL for the github API, for example that of a Github Enterprise instance. The default is the public API https://api.github.com.
 - `render_offline`: Whether to render locally using [Python-Markdown][] (Note: this is a work in progress)
 
 
@@ -333,7 +337,7 @@ Renders the markdown from the specified path or text, without caching,
 and returns an HTML page that resembles the GitHub Readme view.
 
 ```python
-render_page(page=None, gfm=False, context=None, username=None, password=None, render_offline=False, render_wide=False, render_inline=False, text=None)
+render_page(page=None, gfm=False, context=None, username=None, password=None, render_offline=False, render_wide=False, render_inline=False, text=None, api_url=None)
 ```
 
 - `path`: The path to use for the page title, rendering `'README.md'` if None
@@ -342,6 +346,7 @@ render_page(page=None, gfm=False, context=None, username=None, password=None, re
              takes the form of `username/project`
 - `username`: The user to authenticate with GitHub to extend the API limit
 - `password`: The password to authenticate with GitHub to extend the API limit
+- `api_url`: A different base URL for the github API, for example that of a Github Enterprise instance. The default is the public API https://api.github.com.
 - `render_offline`: Whether to render offline using [Python-Markdown][] (Note: this is a work in progress)
 - `render_wide`: Whether to render a wide page, `False` by default (this has no effect when used with `gfm`)
 - `render_inline`: Whether to inline the styles within the HTML file

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ This is the same app used by `serve` and `export` and initializes the cache,
 using the cached styles when available.
 
 ```python
-create_app(path=None, gfm=False, context=None, username=None, password=None, render_offline=False, render_wide=False, render_inline=False, text=None)
+create_app(path=None, gfm=False, context=None, username=None, password=None, api_url=None, render_offline=False, render_wide=False, render_inline=False, text=None)
 ```
 
 - `path`: The filename to render, or the directory containing your Readme file, defaulting to the current working directory
@@ -290,6 +290,7 @@ create_app(path=None, gfm=False, context=None, username=None, password=None, ren
              takes the form of `username/project`
 - `username`: The user to authenticate with GitHub to extend the API limit
 - `password`: The password to authenticate with GitHub to extend the API limit
+- `api_url`: A different base URL for the github API, for example that of a Github Enterprise instance. The default is the public API https://api.github.com.
 - `render_offline`: Whether to render locally using [Python-Markdown][] (Note: this is a work in progress)
 - `render_wide`: Whether to render a wide page, `False` by default (this has no effect when used with `gfm`)
 - `render_inline`: Whether to inline the styles within the HTML file

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ This is the same app used by `serve` and `export` and initializes the cache,
 using the cached styles when available.
 
 ```python
-create_app(path=None, gfm=False, context=None, username=None, render_offline=False, render_wide=False, render_inline=False, text=None, password=None, api_url=None)
+create_app(path=None, gfm=False, context=None, username=None, password=None, render_offline=False, render_wide=False, render_inline=False, text=None, api_url=None)
 ```
 
 - `path`: The filename to render, or the directory containing your Readme file, defaulting to the current working directory

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ This is the same app used by `serve` and `export` and initializes the cache,
 using the cached styles when available.
 
 ```python
-create_app(path=None, gfm=False, context=None, username=None, password=None, api_url=None, render_offline=False, render_wide=False, render_inline=False, text=None)
+create_app(path=None, gfm=False, context=None, username=None, api_url=None, render_offline=False, render_wide=False, render_inline=False, text=None, password=None)
 ```
 
 - `path`: The filename to render, or the directory containing your Readme file, defaulting to the current working directory

--- a/grip/command.py
+++ b/grip/command.py
@@ -77,8 +77,8 @@ def main(argv=None, force_utf8=True):
     if args['--export']:
         try:
             export(args['<path>'], args['--gfm'], args['--context'],
-                   args['--user'], args['--pass'], args['--api-url'],
-                   False, args['--wide'], True, args['<address>'])
+                   args['--user'], args['--pass'], False, args['--wide'],
+                   True, args['<address>'], args['--api-url'])
             return 0
         except ValueError as ex:
             print('Error:', ex)
@@ -95,8 +95,8 @@ def main(argv=None, force_utf8=True):
     # Run server
     try:
         serve(path, host, port, args['--gfm'], args['--context'],
-              args['--user'], args['--pass'], args['--api-url'],
-              False, args['--wide'])
+              args['--user'], args['--pass'], False, args['--wide'], False,
+              args['--api-url'])
         return 0
     except ValueError as ex:
         print('Error:', ex)

--- a/grip/command.py
+++ b/grip/command.py
@@ -23,6 +23,9 @@ Options:
   --clear           Clears the cached styles and assets and exits
   --export          Exports to <path>.html or README.md instead of serving,
                     optionally using [<address>] as the out file (- for stdout)
+  --api-url=<url>   Specify a different base URL for the github API, for example
+                    that of a Github Enterprise instance. The default is the public
+                    API https://api.github.com.
 """
 
 from __future__ import print_function
@@ -74,8 +77,8 @@ def main(argv=None, force_utf8=True):
     if args['--export']:
         try:
             export(args['<path>'], args['--gfm'], args['--context'],
-                   args['--user'], args['--pass'], False, args['--wide'],
-                   True, args['<address>'])
+                   args['--user'], args['--pass'], args['--api-url'],
+                   False, args['--wide'], True, args['<address>'])
             return 0
         except ValueError as ex:
             print('Error:', ex)
@@ -92,7 +95,8 @@ def main(argv=None, force_utf8=True):
     # Run server
     try:
         serve(path, host, port, args['--gfm'], args['--context'],
-              args['--user'], args['--pass'], False, args['--wide'])
+              args['--user'], args['--pass'], args['--api-url'],
+              False, args['--wide'])
         return 0
     except ValueError as ex:
         print('Error:', ex)

--- a/grip/exporter.py
+++ b/grip/exporter.py
@@ -10,16 +10,17 @@ from .renderer import render_app
 
 
 def render_page(path=None, gfm=False, context=None,
-                username=None, password=None,
+                username=None, password=None, api_url=None,
                 render_offline=False, render_wide=False, render_inline=False,
                 text=None):
     """Renders the specified markup text to an HTML page and returns it."""
-    app = create_app(path, gfm, context, username, password,
+    app = create_app(path, gfm, context, username, password, api_url,
                      render_offline, render_wide, render_inline, text)
     return render_app(app)
 
 
 def export(path=None, gfm=False, context=None, username=None, password=None,
+           api_url=None,
            render_offline=False, render_wide=False, render_inline=True,
            out_filename=None):
     """Exports the rendered HTML to a file."""
@@ -33,7 +34,7 @@ def export(path=None, gfm=False, context=None, username=None, password=None,
     if not export_to_stdout:
         print('Exporting to', out_filename, file=sys.stderr)
 
-    page = render_page(path, gfm, context, username, password,
+    page = render_page(path, gfm, context, username, password, api_url,
                        render_offline, render_wide, render_inline)
 
     if export_to_stdout:

--- a/grip/exporter.py
+++ b/grip/exporter.py
@@ -10,19 +10,18 @@ from .renderer import render_app
 
 
 def render_page(path=None, gfm=False, context=None,
-                username=None, password=None, api_url=None,
+                username=None, password=None,
                 render_offline=False, render_wide=False, render_inline=False,
-                text=None):
+                text=None, api_url=None):
     """Renders the specified markup text to an HTML page and returns it."""
-    app = create_app(path, gfm, context, username, password, api_url,
-                     render_offline, render_wide, render_inline, text)
+    app = create_app(path, gfm, context, username, password,
+                     render_offline, render_wide, render_inline, text, api_url)
     return render_app(app)
 
 
 def export(path=None, gfm=False, context=None, username=None, password=None,
-           api_url=None,
            render_offline=False, render_wide=False, render_inline=True,
-           out_filename=None):
+           out_filename=None, api_url=None):
     """Exports the rendered HTML to a file."""
     export_to_stdout = out_filename == '-'
     if out_filename is None:
@@ -34,8 +33,9 @@ def export(path=None, gfm=False, context=None, username=None, password=None,
     if not export_to_stdout:
         print('Exporting to', out_filename, file=sys.stderr)
 
-    page = render_page(path, gfm, context, username, password, api_url,
-                       render_offline, render_wide, render_inline)
+    page = render_page(path, gfm, context, username, password,
+                       render_offline, render_wide, render_inline,
+                       None, api_url)
 
     if export_to_stdout:
       try:

--- a/grip/github_renderer.py
+++ b/grip/github_renderer.py
@@ -2,18 +2,18 @@ import requests
 from flask import abort, json
 
 
-def render_content(text, gfm=False, context=None,
+def render_content(text, api_url, gfm=False, context=None,
                    username=None, password=None):
     """Renders the specified markup using the GitHub API."""
     if gfm:
-        url = 'https://api.github.com/markdown'
+        url = '%s/markdown' % api_url
         data = {'text': text, 'mode': 'gfm'}
         if context:
             data['context'] = context
         data = json.dumps(data, ensure_ascii=False).encode('utf-8')
         headers = {'content-type': 'application/json; charset=UTF-8'}
     else:
-        url = 'https://api.github.com/markdown/raw'
+        url = '%s/markdown/raw' % api_url
         data = text.encode('utf-8')
         headers = {'content-type': 'text/x-markdown; charset=UTF-8'}
 

--- a/grip/github_renderer.py
+++ b/grip/github_renderer.py
@@ -6,14 +6,14 @@ def render_content(text, api_url, gfm=False, context=None,
                    username=None, password=None):
     """Renders the specified markup using the GitHub API."""
     if gfm:
-        url = '%s/markdown' % api_url
+        url = '{}/markdown'.format(api_url)
         data = {'text': text, 'mode': 'gfm'}
         if context:
             data['context'] = context
         data = json.dumps(data, ensure_ascii=False).encode('utf-8')
         headers = {'content-type': 'application/json; charset=UTF-8'}
     else:
-        url = '%s/markdown/raw' % api_url
+        url = '{}/markdown/raw'.format(api_url)
         data = text.encode('utf-8')
         headers = {'content-type': 'text/x-markdown; charset=UTF-8'}
 

--- a/grip/renderer.py
+++ b/grip/renderer.py
@@ -11,7 +11,8 @@ def render_app(app, route='/'):
 
 
 def render_content(text, gfm=False, context=None,
-                   username=None, password=None, render_offline=False):
+                   username=None, password=None, api_url=None,
+                   render_offline=False):
     """Renders the specified markup and returns the result."""
     return (offline_render(text, gfm, context) if render_offline
-        else github_render(text, gfm, context, username, password))
+        else github_render(text, api_url, gfm, context, username, password))

--- a/grip/renderer.py
+++ b/grip/renderer.py
@@ -11,8 +11,8 @@ def render_app(app, route='/'):
 
 
 def render_content(text, gfm=False, context=None,
-                   username=None, password=None, api_url=None,
-                   render_offline=False):
+                   username=None, password=None,
+                   render_offline=False, api_url=None):
     """Renders the specified markup and returns the result."""
     return (offline_render(text, gfm, context) if render_offline
         else github_render(text, api_url, gfm, context, username, password))

--- a/grip/server.py
+++ b/grip/server.py
@@ -29,9 +29,9 @@ except:
 
 
 def create_app(path=None, gfm=False, context=None,
-               username=None, password=None, api_url=None,
+               username=None, password=None,
                render_offline=False, render_wide=False, render_inline=False,
-               text=None):
+               text=None, api_url=None):
     """
     Creates an WSGI application that can serve the specified file or
     directory containing a README.
@@ -137,9 +137,9 @@ def create_app(path=None, gfm=False, context=None,
         favicon = assets.get('favicon', None)
 
         return _render_page(render_text, filename, gfm, context,
-                            username, password, api_url,
+                            username, password,
                             render_offline, render_wide,
-                            style_urls, styles, favicon)
+                            style_urls, styles, favicon, api_url)
 
     @app.route(cache_url + '/octicons/octicons/<filename>')
     def render_octicon(filename=None):
@@ -161,14 +161,15 @@ def create_app(path=None, gfm=False, context=None,
 
 
 def serve(path=None, host=None, port=None, gfm=False, context=None,
-          username=None, password=None, api_url=None,
-          render_offline=False, render_wide=False, render_inline=False):
+          username=None, password=None,
+          render_offline=False, render_wide=False, render_inline=False,
+          api_url=None):
     """
     Starts a server to render the specified file
     or directory containing a README.
     """
-    app = create_app(path, gfm, context, username, password, api_url,
-                     render_offline, render_wide, render_inline)
+    app = create_app(path, gfm, context, username, password,
+                     render_offline, render_wide, render_inline, None, api_url)
 
     # Set overridden config values
     if host is not None:
@@ -236,14 +237,14 @@ def _cache_directory(app):
 
 
 def _render_page(text, filename=None, gfm=False, context=None,
-                 username=None, password=None, api_url=None,
+                 username=None, password=None,
                  render_offline=False, render_wide=False,
-                 style_urls=[], styles=[], favicon=None):
+                 style_urls=[], styles=[], favicon=None, api_url=None):
     """Renders the specified markup text to an HTML page."""
 
     render_title = not gfm
-    content = render_content(text, gfm, context, username, password, api_url,
-                             render_offline)
+    content = render_content(text, gfm, context, username, password,
+                             render_offline, api_url)
 
     return render_template('index.html',
                            content=content, filename=filename,

--- a/grip/server.py
+++ b/grip/server.py
@@ -29,7 +29,7 @@ except:
 
 
 def create_app(path=None, gfm=False, context=None,
-               username=None, password=None,
+               username=None, password=None, api_url=None,
                render_offline=False, render_wide=False, render_inline=False,
                text=None):
     """
@@ -63,6 +63,7 @@ def create_app(path=None, gfm=False, context=None,
     cache_directory = _cache_directory(app)
     username = username if username is not None else app.config.get('USERNAME')
     password = password if password is not None else app.config.get('PASSWORD')
+    api_url = api_url if api_url is not None else app.config.get('API_URL')
 
     # Authentication message
     is_authenticated = bool(username) or bool(password)
@@ -136,7 +137,7 @@ def create_app(path=None, gfm=False, context=None,
         favicon = assets.get('favicon', None)
 
         return _render_page(render_text, filename, gfm, context,
-                            username, password,
+                            username, password, api_url,
                             render_offline, render_wide,
                             style_urls, styles, favicon)
 
@@ -160,13 +161,13 @@ def create_app(path=None, gfm=False, context=None,
 
 
 def serve(path=None, host=None, port=None, gfm=False, context=None,
-          username=None, password=None,
+          username=None, password=None, api_url=None,
           render_offline=False, render_wide=False, render_inline=False):
     """
     Starts a server to render the specified file
     or directory containing a README.
     """
-    app = create_app(path, gfm, context, username, password,
+    app = create_app(path, gfm, context, username, password, api_url,
                      render_offline, render_wide, render_inline)
 
     # Set overridden config values
@@ -235,13 +236,13 @@ def _cache_directory(app):
 
 
 def _render_page(text, filename=None, gfm=False, context=None,
-                 username=None, password=None,
+                 username=None, password=None, api_url=None,
                  render_offline=False, render_wide=False,
                  style_urls=[], styles=[], favicon=None):
     """Renders the specified markup text to an HTML page."""
 
     render_title = not gfm
-    content = render_content(text, gfm, context, username, password,
+    content = render_content(text, gfm, context, username, password, api_url,
                              render_offline)
 
     return render_template('index.html',

--- a/grip/settings.py
+++ b/grip/settings.py
@@ -22,6 +22,7 @@ USERNAME = None
 PASSWORD = None
 
 
+API_URL = 'https://api.github.com'
 CACHE_DIRECTORY = 'cache-{version}'
 CACHE_URL = '/grip-cache'
 STATIC_URL_PATH = '/grip-static'


### PR DESCRIPTION
This PR allows an alternative github API URL to be specified on the command line. This allows Github Enterprise users to use their private APIs to render markdown (e.g. for privacy reasons, as well as linking correctly with the `--context` option).

### Testing

I haven't added any tests for this feature. I've tested manually with

```
pip install -e 'git+git@github.com:dandavison/grip.git@api-url#egg=grip'
```

checking that normal invocation works, and also invocation against a GHE instance with something like

```
grip --api-url https://github.counsyl.com/api/v3 --user dan --pass <access_token> --context owner/repo --gfm PR.md
```