### PR TITLE
Add autorefresh

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -20,6 +20,7 @@ along with the following contributors:
 - Sriram Sundarraj ([@ssundarraj](https://github.com/ssundarraj))
 - Jose Honorato ([@jlhonora](https://github.com/jlhonora)
 - Aka.Why ([@akawhy](https://github.com/akawhy))
+- Mark Thomas ([@markbt](https://github.com/markbt))
 
 
 [home]: README.md

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ This is the same app used by `serve` and `export` and initializes the cache,
 using the cached styles when available.
 
 ```python
-create_app(path=None, gfm=False, context=None, username=None, password=None, render_offline=False, render_wide=False, render_inline=False, api_url=None, title=None, text=None)
+create_app(path=None, gfm=False, context=None, username=None, password=None, render_offline=False, render_wide=False, render_inline=False, api_url=None, title=None, text=None, autorefresh=False)
 ```
 
 - `path`: The filename to render, or the directory containing your Readme file, defaulting to the current working directory
@@ -301,6 +301,7 @@ create_app(path=None, gfm=False, context=None, username=None, password=None, ren
 - `api_url`: A different base URL for the github API, for example that of a Github Enterprise instance. The default is the public API https://api.github.com.
 - `title`: The page title, derived from `path` by default
 - `text`: A string or stream of Markdown text to render instead of being loaded from `path` (Note: `path` can be used to set the page title)
+- `autorefresh`: The app will generate client-side code to autorefresh the page when the file is changed.
 
 
 #### render_app

--- a/grip/exporter.py
+++ b/grip/exporter.py
@@ -17,7 +17,7 @@ def render_page(path=None, gfm=False, context=None,
     Renders the specified markup text to an HTML page and returns it.
     """
     app = create_app(path, gfm, context, username, password, render_offline,
-                     render_wide, render_inline, api_url, title, text)
+                     render_wide, render_inline, api_url, title, text, False)
     return render_app(app)
 
 

--- a/grip/server.py
+++ b/grip/server.py
@@ -137,6 +137,7 @@ def create_app(path=None, gfm=False, context=None,
                             "updated_at": int(mtime),
                         }
                         update_text = json.dumps(update)
+                        print(" * File updated at %s." % time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(mtime)))
                         yield "data: %s\r\n\r\n" % update_text
                         orig_mtime = mtime
             except GeneratorExit:

--- a/grip/server.py
+++ b/grip/server.py
@@ -214,6 +214,7 @@ def serve(path=None, host=None, port=None, gfm=False, context=None,
         browser_thread = threading.Thread(
             target=wait_and_start_browser,
             args=(app.config['HOST'], app.config['PORT']))
+        browser_thread.daemon = True
         browser_thread.start()
 
     # Run local server

--- a/grip/server.py
+++ b/grip/server.py
@@ -226,6 +226,9 @@ def serve(path=None, host=None, port=None, gfm=False, context=None,
     if browser:
         browser_thread.join()
 
+    # Exit the process (this terminates the werkzeug threads)
+    os._exit(0)
+
 
 def clear_cache():
     """

--- a/grip/server.py
+++ b/grip/server.py
@@ -5,9 +5,11 @@ import io
 import os
 import re
 import sys
+import json
 import errno
 import shutil
 import base64
+import time
 import mimetypes
 import threading
 import posixpath
@@ -16,7 +18,7 @@ from traceback import format_exc
 import requests
 from flask import (
     Flask, abort, make_response, redirect, render_template, request, safe_join,
-    send_from_directory, url_for)
+    send_from_directory, url_for, Response)
 
 from . import __version__
 from .constants import default_filenames
@@ -32,7 +34,7 @@ except ImportError:
 def create_app(path=None, gfm=False, context=None,
                username=None, password=None,
                render_offline=False, render_wide=False, render_inline=False,
-               api_url=None, title=None, text=None):
+               api_url=None, title=None, text=None, autorefresh=False):
     """
     Creates an WSGI application that can serve the specified file or
     directory containing a README.
@@ -115,6 +117,33 @@ def create_app(path=None, gfm=False, context=None,
             style_urls[:] = []
 
     # Views
+    @app.route('/grip-updates/')
+    @app.route('/grip-updates/<path:filename>')
+    def render_updates(filename=None):
+        if filename is None:
+            filename = in_filename
+        def gen():
+            orig_mtime = os.path.getmtime(filename)
+            try:
+                while True:
+                    time.sleep(1)
+                    mtime = os.path.getmtime(filename)
+                    if mtime != orig_mtime:
+                        yield "data: %s\r\n\r\n" % json.dumps({'updating': 'true'})
+                        render_text = _read_file_or_404(filename)
+                        update = { "new_content":
+                            render_content(render_text, gfm, context, username, password,
+                                render_offline, api_url),
+                            "updated_at": int(mtime),
+                        }
+                        update_text = json.dumps(update)
+                        yield "data: %s\r\n\r\n" % update_text
+                        orig_mtime = mtime
+            except GeneratorExit:
+                pass
+
+        return Response(gen(), mimetype="text/event-stream")
+
     @app.route('/')
     @app.route('/<path:filename>')
     def render(filename=None):
@@ -146,7 +175,7 @@ def create_app(path=None, gfm=False, context=None,
 
         return _render_page(render_text, filename, gfm, context, username,
                             password, render_offline, render_wide, style_urls,
-                            styles, favicon, api_url, title)
+                            styles, favicon, api_url, title, autorefresh)
 
     @app.route('{}/<path:filename>'.format(cache_url))
     def render_cache(filename=None):
@@ -172,7 +201,7 @@ def serve(path=None, host=None, port=None, gfm=False, context=None,
     or directory containing a README.
     """
     app = create_app(path, gfm, context, username, password, render_offline,
-                     render_wide, render_inline, api_url, title, None)
+                     render_wide, render_inline, api_url, title, None, True)
 
     # Set overridden config values
     if host is not None:
@@ -189,7 +218,7 @@ def serve(path=None, host=None, port=None, gfm=False, context=None,
 
     # Run local server
     app.run(app.config['HOST'], app.config['PORT'], debug=app.debug,
-            use_reloader=app.config['DEBUG_GRIP'])
+            use_reloader=app.config['DEBUG_GRIP'], threaded=True)
 
     # Closing browser
     if browser:
@@ -258,7 +287,7 @@ def _render_page(text, filename=None, gfm=False, context=None,
                  username=None, password=None,
                  render_offline=False, render_wide=False,
                  style_urls=[], styles=[], favicon=None, api_url=None,
-                 title=None):
+                 title=None, autorefresh=False):
     """
     Renders the specified markup text to an HTML page.
     """
@@ -276,7 +305,8 @@ def _render_page(text, filename=None, gfm=False, context=None,
                            favicon=favicon,
                            render_title=render_title,
                            discussion=gfm,
-                           title=title)
+                           title=title,
+                           autorefresh=autorefresh)
 
 
 def _render_image(image_data, content_type):

--- a/grip/templates/index.html
+++ b/grip/templates/index.html
@@ -31,6 +31,12 @@
     .timeline-comment-wrapper > .timeline-comment:before {
       content: none;
     }
+    /* Updated at */
+    .grip-updated-at {
+      font-size: 10px;
+      font-weight: normal;
+      font-style: italic;
+    }
   </style>
 {%- endblock -%}
 
@@ -63,6 +69,23 @@
       scrollToHash();
     }
     showCanonicalImages();
+  {% if autorefresh %}
+    var source = new EventSource("/grip-updates/{{ filename }}");
+    source.onmessage = function(ev) {
+      var msg = JSON.parse(ev.data);
+      if (msg.updating) {
+        var updated_at = document.getElementById('grip-updated-at');
+        updated_at.innerHTML = "(updating...)";
+      } else {
+        console.log("File updated at " + msg.updated_at);
+        var content = document.getElementById('grip-content');
+        content.innerHTML = msg.new_content;
+        var updated_at = document.getElementById('grip-updated-at');
+        var updated_at_date = new Date(msg.updated_at * 1000)
+        updated_at.innerHTML = "(updated at " + updated_at_date.toLocaleDateString() + " " + updated_at_date.toLocaleTimeString() + ")";
+      }
+    }
+  {% endif %}
   </script>
 {%- endblock -%}
 
@@ -77,7 +100,7 @@
               <div class="timeline-comment">
                 <div class="comment">
                   <div class="comment-content">
-                    <div class="comment-body markdown-body markdown-format">
+                    <div id="grip-content" class="comment-body markdown-body markdown-format">
                       {{ content|safe }}
                     </div>
                   </div>
@@ -92,9 +115,10 @@
                 <h3>
                   <span class="octicon octicon-book"></span>
                   {{ title }}
+                  <span id="grip-updated-at" class="grip-updated-at"></span>
                 </h3>
               {% endif %}
-              <div class="markdown-body entry-content">
+              <div id="grip-content" class="markdown-body entry-content">
                 {{ content|safe }}
               </div>
             </div>

--- a/grip/templates/index.html
+++ b/grip/templates/index.html
@@ -31,12 +31,6 @@
     .timeline-comment-wrapper > .timeline-comment:before {
       content: none;
     }
-    /* Updated at */
-    .grip-updated-at {
-      padding: 8px;
-      font-size: 12px;
-      color: #767676;
-    }
   </style>
 {%- endblock -%}
 
@@ -74,15 +68,12 @@
     source.onmessage = function(ev) {
       var msg = JSON.parse(ev.data);
       if (msg.updating) {
-        var updated_at = document.getElementById('grip-updated-at');
-        updated_at.innerHTML = "Updating...";
+        document.title = document.title + " (updating)";
       } else {
         console.log("File updated at " + msg.updated_at);
         var content = document.getElementById('grip-content');
         content.innerHTML = msg.new_content;
-        var updated_at = document.getElementById('grip-updated-at');
-        var updated_at_date = new Date(msg.updated_at * 1000)
-        updated_at.innerHTML = "Updated at " + updated_at_date.toLocaleDateString() + " " + updated_at_date.toLocaleTimeString();
+        document.title = document.title.replace(/ \(updating\)/g, "");
       }
     }
   {% endif %}
@@ -92,11 +83,6 @@
 {%- block page -%}
   <div class="preview-page">
     <div class="container">
-      {% if autorefresh %}
-        <div class="grip-updated-at">
-          <span id="grip-updated-at">&nbsp;</span>
-        </div>
-      {% endif %}
       <div class="repository-with-sidebar repo-container {{ 'with-full-navigation' if not render_wide }}">
 
         {% if discussion %}

--- a/grip/templates/index.html
+++ b/grip/templates/index.html
@@ -33,9 +33,9 @@
     }
     /* Updated at */
     .grip-updated-at {
-      font-size: 10px;
-      font-weight: normal;
-      font-style: italic;
+      padding: 8px;
+      font-size: 12px;
+      color: #767676;
     }
   </style>
 {%- endblock -%}
@@ -75,14 +75,14 @@
       var msg = JSON.parse(ev.data);
       if (msg.updating) {
         var updated_at = document.getElementById('grip-updated-at');
-        updated_at.innerHTML = "(updating...)";
+        updated_at.innerHTML = "Updating...";
       } else {
         console.log("File updated at " + msg.updated_at);
         var content = document.getElementById('grip-content');
         content.innerHTML = msg.new_content;
         var updated_at = document.getElementById('grip-updated-at');
         var updated_at_date = new Date(msg.updated_at * 1000)
-        updated_at.innerHTML = "(updated at " + updated_at_date.toLocaleDateString() + " " + updated_at_date.toLocaleTimeString() + ")";
+        updated_at.innerHTML = "Updated at " + updated_at_date.toLocaleDateString() + " " + updated_at_date.toLocaleTimeString();
       }
     }
   {% endif %}
@@ -92,6 +92,9 @@
 {%- block page -%}
   <div class="preview-page">
     <div class="container">
+      <div class="grip-updated-at">
+        <span id="grip-updated-at">&nbsp;</span>
+      </div>
       <div class="repository-with-sidebar repo-container {{ 'with-full-navigation' if not render_wide }}">
 
         {% if discussion %}
@@ -115,7 +118,6 @@
                 <h3>
                   <span class="octicon octicon-book"></span>
                   {{ title }}
-                  <span id="grip-updated-at" class="grip-updated-at"></span>
                 </h3>
               {% endif %}
               <div id="grip-content" class="markdown-body entry-content">

--- a/grip/templates/index.html
+++ b/grip/templates/index.html
@@ -92,9 +92,11 @@
 {%- block page -%}
   <div class="preview-page">
     <div class="container">
-      <div class="grip-updated-at">
-        <span id="grip-updated-at">&nbsp;</span>
-      </div>
+      {% if autorefresh %}
+        <div class="grip-updated-at">
+          <span id="grip-updated-at">&nbsp;</span>
+        </div>
+      {% endif %}
       <div class="repository-with-sidebar repo-container {{ 'with-full-navigation' if not render_wide }}">
 
         {% if discussion %}


### PR DESCRIPTION
I added autorefresh support.

This is somewhat like what's in joeyespo/grip#19 (I must admit, I didn't see that until *after* I'd written the code), but I think it might be a better implementation.

This implementation uses an event stream, in-place content replacement, and is triggered by the file changing.  This means:
- We only have HTTP traffic and thus a hit to github when the file actually changes.
- The update happens after about a second (can tweak the polling time in server.py, but I found 1s was adequate).
- If you're scrolled a long way down the document, it won't scroll back up to the top or to the last anchor you were at (as happens with a reload).
