### PR TITLE
Stop browser opening consuming all the sockets

### DIFF
--- a/grip/browser.py
+++ b/grip/browser.py
@@ -1,5 +1,6 @@
 import socket
 import webbrowser
+import time
 
 
 def is_server_running(host, port):
@@ -8,7 +9,8 @@ def is_server_running(host, port):
     host and port.
     """
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    return not sock.connect_ex((host, port)) == 0
+    rc = sock.connect_ex((host, port))
+    return rc == 0
 
 
 def wait_for_server(host, port):
@@ -20,7 +22,7 @@ def wait_for_server(host, port):
     the Flask server.
     """
     while not is_server_running(host, port):
-        pass
+        time.sleep(0.1)
 
 
 def start_browser(url):


### PR DESCRIPTION
The sense of the test in `is_server_running` is inverted.

This means `wait_for_server` races with the server starting:
- If the server starts first, `wait_for_server` will never return, and will quickly consume all available ephemeral ports on the system.
- If the server doesn't start first, `wait_for_server` returns immediately and the browser opens to a blank page.

This fix:
- Fixes the sense of the test, and makes the code more explicit
- Adds a delay in `wait_for_server` so that ephemeral sockets aren't rapidly consumed while we wait for it to start.