### PR TITLE
feat: #164 Expose render_inline parameter to the users

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -22,6 +22,7 @@ along with the following contributors:
 - Aka.Why ([@akawhy](https://github.com/akawhy))
 - Mark Thomas ([@markbt](https://github.com/markbt))
 - Gastón N. Charkiewicz ([@mekoda](https://github.com/mekoda))
+- Matthew R. Tanudjaja ([@mrexmelle](https://github.com/mrexmelle))
 
 
 [home]: README.md

--- a/grip/command.py
+++ b/grip/command.py
@@ -36,7 +36,9 @@ Options:
   --norefresh               Do not automatically refresh the Readme content when
                             the file changes.
   --quiet                   Do not print to the terminal.
-  --inline=<true/false>     Renders CSS inline in the html. The default is True.
+  --inline=<true/false>     Renders CSS inline in the html.
+                            If --export is specified, the default is True.
+                            Otherwise, the default is False.
 """
 
 from __future__ import print_function

--- a/grip/command.py
+++ b/grip/command.py
@@ -15,27 +15,28 @@ Where:
   <address> is what to listen on, of the form <host>[:<port>], or just <port>
 
 Options:
-  --user-content    Render as user-content like comments or issues.
-  --context=<repo>  The repository context, only taken into account
-                    when using --user-content.
-  --user=<username> A GitHub username for API authentication. If used
-                    without the --pass option, an upcoming password
-                    input will be necessary.
-  --pass=<password> A GitHub password or auth token for API auth.
-  --wide            Renders wide, i.e. when the side nav is collapsed.
-  --clear           Clears the cached styles and assets and exits.
-  --export          Exports to <path>.html or README.md instead of
-                    serving, optionally using [<address>] as the out
-                    file (- for stdout).
-  -b --browser      Open a tab in the browser after the server starts.
-  --api-url=<url>   Specify a different base URL for the github API,
-                    for example that of a Github Enterprise instance.
-                    Default is the public API: https://api.github.com
-  --title=<title>   Manually sets the page's title.
-                    The default is the filename.
-  --norefresh       Do not automatically refresh the Readme content when
-                    the file changes.
-  --quiet           Do not print to the terminal
+  --user-content            Render as user-content like comments or issues.
+  --context=<repo>          The repository context, only taken into account
+                            when using --user-content.
+  --user=<username>         A GitHub username for API authentication. If used
+                            without the --pass option, an upcoming password
+                            input will be necessary.
+  --pass=<password>         A GitHub password or auth token for API auth.
+  --wide                    Renders wide, i.e. when the side nav is collapsed.
+  --clear                   Clears the cached styles and assets and exits.
+  --export                  Exports to <path>.html or README.md instead of
+                            serving, optionally using [<address>] as the out
+                            file (- for stdout).
+  -b --browser              Open a tab in the browser after the server starts.
+  --api-url=<url>           Specify a different base URL for the github API,
+                            for example that of a Github Enterprise instance.
+                            Default is the public API: https://api.github.com
+  --title=<title>           Manually sets the page's title.
+                            The default is the filename.
+  --norefresh               Do not automatically refresh the Readme content when
+                            the file changes.
+  --quiet                   Do not print to the terminal.
+  --inline=<true/false>     Renders CSS inline in the html. The default is True.
 """
 
 from __future__ import print_function
@@ -94,12 +95,27 @@ def main(argv=None, force_utf8=True):
     if args['--user'] and not password:
         password = getpass()
 
+    # Get render_inline value
+    inline_str=args['--inline']
+    inline_bool=None
+    if inline_str:
+        inline_str=inline_str.lower()
+        if inline_str=='true':
+            inline_bool=True
+        elif inline_str=='false':
+            inline_bool=False
+        else:
+            print('inline argument only accepts True or False value')
+            return 1
+
     # Export to a file instead of running a server
     if args['--export']:
+        if inline_bool==None:
+            inline_bool=True
         try:
             export(args['<path>'], args['--user-content'], args['--context'],
                    args['--user'], password, False, args['--wide'],
-                   True, args['<address>'], args['--api-url'], args['--title'])
+                   inline_bool, args['<address>'], args['--api-url'], args['--title'])
             return 0
         except ReadmeNotFoundError as ex:
             print('Error:', ex)
@@ -115,8 +131,10 @@ def main(argv=None, force_utf8=True):
 
     # Run server
     try:
+        if inline_bool==None:
+            inline_bool=False
         serve(path, host, port, args['--user-content'], args['--context'],
-              args['--user'], password, False, args['--wide'], False,
+              args['--user'], password, False, args['--wide'], inline_bool,
               args['--api-url'], args['--title'], not args['--norefresh'],
               args['--browser'], args['--quiet'], None)
         return 0


### PR DESCRIPTION
This fork is created to expose render_inline parameter to the users. The users will see a new parameter (--inline) in the help menu.

Exposing render_inline to the users gives them flexibility whether to have the css styles separated or inlined in the html. The default will still be True when exporting, and False when grip is used as a service.