### PR TITLE
PoC: catch-up with latest GitHub changes

### DIFF
--- a/grip/templates/base.html
+++ b/grip/templates/base.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <title>{% block title %}Grip{% endblock %}</title>
   <link rel="icon" href="{{ favicon or url_for('static', filename='favicon.ico') }}" />
+  <link rel="stylesheet" href="//octicons.github.com/components/octicons/octicons/octicons.css">
   {%- block styles %}{% endblock %}
 </head>
 <body>

--- a/grip/templates/index.html
+++ b/grip/templates/index.html
@@ -118,7 +118,7 @@
           </div>
         {% else %}
           <div class="repository-content context-loader-container">
-            <div id="readme" class="boxed-group flush clearfix announce instapaper_body md">
+            <div id="readme" class="readme boxed-group clearfix announce instapaper_body md">
               {% if not user_content and title %}
                 <h3>
                   <span class="octicon octicon-book"></span>


### PR DESCRIPTION
These are the minimal changes that I could find to make READMEs rendered
by grip have the same look-and-feel as a GitHub rendered README. This is
just a spike/proof-of-concept.  Though I believe I did not break any
functionality, no new tests were added and some existing tests began
failing.

- add octicon stylesheet
- updated classes of div#readme to be consistent with GitHub