### PR TITLE
Add Documentation Generation Workflow into Tips section of README.md

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -18,7 +18,7 @@ along with the following contributors:
 - Zhiming Wang ([@zmwangx](https://github.com/zmwangx))
 - Dan Davison ([@dandavison](https://github.com/dandavison))
 - Sriram Sundarraj ([@ssundarraj](https://github.com/ssundarraj))
-- Jose Honorato ([@jlhonora](https://github.com/jlhonora)
+- Jose Honorato ([@jlhonora](https://github.com/jlhonora))
 - Aka.Why ([@akawhy](https://github.com/akawhy))
 - Mark Thomas ([@markbt](https://github.com/markbt))
 - Gastón N. Charkiewicz ([@mekoda](https://github.com/mekoda))

--- a/README.md
+++ b/README.md
@@ -187,6 +187,34 @@ $ grip
 
 *By [Joshua Gourneau](https://twitter.com/gourneau/status/636329126643658753)*.
 
+#### Create a documentation set of HTML pages
+
+As an example, if I want to convert all md files in $HOME/Documents/docs directory to html files, and produce a documentation tarball with name docs.tgz containing these html files and the github css styles, these are what I'm gonna do:
+
+-  Changing working directory to that directory.
+   ```bash
+   $ cd $HOME/Documents/docs
+   ```
+-  Changing the value of CACHE_DIRECTORY in $HOME/.grip/settings.py to '../Documents/docs/asset'
+-  Set GRIPURL to current directory.
+   ```bash
+   $ export GRIPURL=$(PWD)
+   ```
+- Export all your md files using Grip.
+   ```bash
+   $ for f in *.md; do grip --export $f --inline=False; done
+   ```      
+- Replace absolute asset paths in html files with relative paths.
+   ```bash
+   $ for f in *.html; do sed -i '' "s?$GRIPURL/??g" $f; done
+   ```
+- Compress the entire html and the asset directory into docs.tgz tarball.
+  ```bash
+  $ tar -czvf docs.tgz `ls | grep [\.]html$` asset
+  ```
+  
+*By [Matthew R. Tanudjaja](https://github.com/mrexmelle)*.  
+
 *Want to share your own? [Say hello][twitter] or [see below](#contributing).*
 
 

--- a/README.md
+++ b/README.md
@@ -189,14 +189,14 @@ $ grip
 
 #### Create a documentation set of HTML pages
 
-As an example, if I want to convert all md files in $HOME/Documents/docs directory to html files, and produce a documentation tarball with name docs.tgz containing these html files and the github css styles, these are what I'm gonna do:
+As an example, if you want to convert all md files in $HOME/Documents/docs directory to html files, and produce a documentation tarball with name docs.tgz containing these html files and the github css styles, these are the step=by-step instruction that you should follow:
 
--  Changing working directory to that directory.
+-  Change working directory to that directory.
    
    ```bash
    $ cd $HOME/Documents/docs
    ```
--  Changing the value of CACHE_DIRECTORY in $HOME/.grip/settings.py to '../Documents/docs/asset'
+-  Change the value of CACHE_DIRECTORY in $HOME/.grip/settings.py to '../Documents/docs/asset'
 -  Set GRIPURL to current directory.
    
    ```bash

--- a/README.md
+++ b/README.md
@@ -192,26 +192,31 @@ $ grip
 As an example, if I want to convert all md files in $HOME/Documents/docs directory to html files, and produce a documentation tarball with name docs.tgz containing these html files and the github css styles, these are what I'm gonna do:
 
 -  Changing working directory to that directory.
+   
    ```bash
    $ cd $HOME/Documents/docs
    ```
 -  Changing the value of CACHE_DIRECTORY in $HOME/.grip/settings.py to '../Documents/docs/asset'
 -  Set GRIPURL to current directory.
+   
    ```bash
    $ export GRIPURL=$(PWD)
    ```
-- Export all your md files using Grip.
+-  Export all your md files using Grip.
+   
    ```bash
    $ for f in *.md; do grip --export $f --inline=False; done
    ```      
-- Replace absolute asset paths in html files with relative paths.
+-  Replace absolute asset paths in html files with relative paths.
+   
    ```bash
    $ for f in *.html; do sed -i '' "s?$GRIPURL/??g" $f; done
    ```
-- Compress the entire html and the asset directory into docs.tgz tarball.
-  ```bash
-  $ tar -czvf docs.tgz `ls | grep [\.]html$` asset
-  ```
+-  Compress the entire html and the asset directory into docs.tgz tarball.
+   
+   ```bash
+   $ tar -czvf docs.tgz `ls | grep [\.]html$` asset
+   ```
   
 *By [Matthew R. Tanudjaja](https://github.com/mrexmelle)*.  
 


### PR DESCRIPTION
As discussed in #165 , this pull request is made to provide tips for those who want to generate an HTML-based documentation from markdown files.
