### PR TITLE
Use Flask.before_request instead of Flask.before_first_request to work around the re-entry deadlock introduced in Flask 0.11

### DIFF
--- a/grip/app.py
+++ b/grip/app.py
@@ -128,7 +128,8 @@ class Grip(Flask):
         rate_limit_route = posixpath.join(grip_url, 'rate-limit-preview')
 
         # Initialize views
-        self.before_first_request(self._retrieve_styles)
+        self._styles_retrieved = False
+        self.before_request(self._retrieve_styles)
         self.add_url_rule(asset_route, 'asset', self._render_asset)
         self.add_url_rule(asset_subpath, 'asset', self._render_asset)
         self.add_url_rule('/', 'render', self._render_page)
@@ -310,6 +311,10 @@ class Grip(Flask):
         Retrieves the style URLs from the source and caches them. This
         is called before the first request is dispatched.
         """
+        if self._styles_retrieved:
+            return
+        self._styles_retrieved = True
+
         try:
             self.assets.retrieve_styles(url_for('asset'))
         except Exception as ex:


### PR DESCRIPTION
Fixes #182.

Flask [changed its behavior](https://github.com/pallets/flask/commit/280d8659601a5e3b8dab77231d9f9fc16f5cd1ce) in 0.11 by making `before_first_request` [deadlock](https://github.com/pallets/flask/commit/280d8659601a5e3b8dab77231d9f9fc16f5cd1ce#diff-c3c1b62367ae818e58e148e2e1840b39R1492) if the handler causes another request before finishing. The `_before_request` hook is still re-entrant, so this can be fixed without changing much code.

Note that Flask's change in behavior [addresses some real problems](https://github.com/pallets/flask/issues/879). So a larger, more proper fix later on could be to change [`Grip._retrieve_styles`](https://github.com/joeyespo/grip/blob/master/grip/app.py#L308-L322) (or more specifically, [`Grip._get_styles`](https://github.com/joeyespo/grip/blob/master/grip/app.py#L284-L295)) to access the cached files directly instead of using a request to do so.
