### PR TITLE
Allow --clear to work without a README file present

### DIFF
--- a/grip/api.py
+++ b/grip/api.py
@@ -66,7 +66,7 @@ def clear_cache(grip_class=None):
     """
     if grip_class is None:
         grip_class = Grip
-    grip_class().clear_cache()
+    grip_class(StdinReader()).clear_cache()
 
 
 def render_page(path=None, user_content=False, context=None,


### PR DESCRIPTION
I just tried to run `grip --clear` from the default terminal location, which has no README.md file, and it failed. This tweaks the command to let you run it from anywhere.
