### PR TITLE
Fix tests by patching sys.exc_clear to work on pypy3

### DIFF
--- a/grip/__init__.py
+++ b/grip/__init__.py
@@ -10,6 +10,12 @@ Render local readme files before sending off to GitHub.
 
 __version__ = '4.2.0'
 
+import sys
+
+# Patch for Flask 11.0+ on Python 3 (pypy3)
+if not hasattr(sys, 'exc_clear'):
+    sys.exc_clear = lambda: None
+
 from .api import (
     clear_cache, create_app, export, render_content, render_page, serve)
 from .app import Grip


### PR DESCRIPTION
Namely, [this line from Flask](https://github.com/pallets/flask/blob/0.11/flask/_compat.py#L78).
