### PR TITLE
Fix minor version check

### DIFF
--- a/grip/command.py
+++ b/grip/command.py
@@ -65,7 +65,7 @@ def main(argv=None, force_utf8=True, patch_svg=True):
     if force_utf8 and sys.version_info[0] == 2:
         reload(sys)
         sys.setdefaultencoding('utf-8')
-    if patch_svg and sys.version_info[0] == 2 and sys.version_info[2] <= 6:
+    if patch_svg and sys.version_info[0] == 2 and sys.version_info[1] <= 6:
         mimetypes.add_type('image/svg+xml', '.svg')
 
     if argv is None:


### PR DESCRIPTION
To target Python 2.6 and below, `sys.version_info[0]` and `sys.version_info[1]` need to be checked, not `sys.version_info[2]`.