### PR TITLE
Show '- Grip' on the title only, not the page header

### DIFF
--- a/grip/app.py
+++ b/grip/app.py
@@ -158,12 +158,6 @@ class Grip(Flask):
         if normalized != subpath:
             return redirect(normalized)
 
-        # Get the contextual or overridden title
-        title = self.title
-        if title is None:
-            filename = self.reader.filename_for(subpath)
-            title = ' - '.join([filename or '', 'Grip'])
-
         # Read the Readme text or asset
         try:
             text = self.reader.read(subpath)
@@ -194,7 +188,8 @@ class Grip(Flask):
                            else None)
 
         return render_template(
-            'index.html', title=title, content=content, favicon=favicon,
+            'index.html', filename=self.reader.filename_for(subpath),
+            title=self.title, content=content, favicon=favicon,
             user_content=self.renderer.user_content,
             wide_style=self.render_wide, style_urls=self.assets.style_urls,
             styles=self.assets.styles, autorefresh_url=autorefresh_url)

--- a/grip/templates/index.html
+++ b/grip/templates/index.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}{{ title }}{% endblock %}
+{% block title %}{% if title %}{{ title }}{% else %}{{ filename or '' }} - Grip{% endif %}{% endblock %}
 
 {%- block styles -%}
   {%- for style_url in style_urls %}
@@ -108,10 +108,10 @@
         <div class="container new-discussion-timeline experiment-repo-nav">
           <div class="repository-content">
             <div id="readme" class="readme boxed-group clearfix announce instapaper_body md">
-              {% if not user_content and title %}
+              {% if not user_content and title or filename %}
                 <h3>
                   <span class="octicon octicon-book"></span>
-                  {{ title }}
+                  {% if title %}{{ title }}{% else %}{{ filename }}{% endif %}
                 </h3>
               {% endif %}
               <article class="markdown-body entry-content" itemprop="text" id="grip-content">


### PR DESCRIPTION
This more closely matches GitHub's on-page title.
