### PR TITLE
Remove download count since it's broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@ Grip -- GitHub Readme Instant Preview
 =====================================
 
 [![Current version on PyPI](http://img.shields.io/pypi/v/grip.svg)][pypi]
-[![Downloads/month on PyPI](http://img.shields.io/pypi/dm/grip.svg)][pypi]
 <a href="https://gratipay.com/grip/" title="Thank you!" target="_blank">
   <img src="https://img.shields.io/gratipay/grip.svg" alt="Thank you!">
 </a>


### PR DESCRIPTION
[Relevant StackOverflow answer](http://stackoverflow.com/questions/38102317/why-pypi-doesnt-show-download-stats-anymore) (direct link to email conversation) and [PyPI issue](https://bitbucket.org/pypa/pypi/issues/396/download-stats-have-stopped-working-again).
