### PR TITLE
Fix setup.py install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     license='MIT',
     platforms='any',
     packages=find_packages(),
-    package_data={'grip': ['static/*', 'static/octicons/*', 'templates/*']},
+    package_data={'grip': ['static/*.*', 'static/octicons/*', 'templates/*']},
     install_requires=read('requirements.txt').splitlines(),
     extras_require={'tests': read('requirements-test.txt').splitlines()},
     zip_safe=False,


### PR DESCRIPTION
This fixes another aspect of #196.

#198 fixed the missing octicons. This PR fixes mistreating `static/octicons` as a file.
