### PR TITLE
Use triple-quoted raw strings in regexp constants

### DIFF
--- a/grip/constants.py
+++ b/grip/constants.py
@@ -26,10 +26,10 @@ DEFAULT_API_URL = 'https://api.github.com'
 # Style parsing
 STYLE_URLS_SOURCE = 'https://github.com/joeyespo/grip'
 STYLE_URLS_RE = (
-    '<link.+href=[\'"]?([^\'" >]+)[\'"]?.+media=[\'"]?(?:screen|all)[\'"]?.'
-    '+rel=[\'"]?stylesheet[\'"]?.+/>')
+    r'''<link.+href=['"]?([^'" >]+)['"]?.+media=['"]?(?:screen|all)['"]?.'''
+    r'''+rel=['"]?stylesheet['"]?.+/>''')
 STYLE_ASSET_URLS_RE = (
-    'url\([\'"]?(/static/fonts/octicons/[^\'" \)]+)[\'"]?\)')
+    r'''url\(['"]?(/static/fonts/octicons/[^'" \)]+)['"]?\)''')
 STYLE_ASSET_URLS_SUB_FORMAT = r'url("{0}\1")'
 STYLE_ASSET_URLS_INLINE_FORMAT = (
-    'url\([\'"]?((?:/static|{0})/[^\'" \)]+)[\'"]?\)')
+    r'''url\(['"]?((?:/static|{0})/[^'" \)]+)['"]?\)''')


### PR DESCRIPTION
This reduces the number of needed escape sequences, and fixes Python 3.6 warnings:
```
grip/constants.py:32: DeprecationWarning: invalid escape sequence \(
grip/constants.py:35: DeprecationWarning: invalid escape sequence \(
```

The anomalous escape sequences were found using [pydiatra](https://github.com/jwilk/pydiatra).