### PR TITLE
Fix #179 Detect pdf's as binary not text.

### DIFF
--- a/grip/readers.py
+++ b/grip/readers.py
@@ -222,7 +222,9 @@ class DirectoryReader(ReadmeReader):
         Gets whether the specified subpath is a supported binary file.
         """
         mimetype = self.mimetype_for(subpath)
-        return mimetype is not None and mimetype.startswith('image/')
+        if mimetype and mimetype.startswith('text/'):
+            return False
+        return True
 
     def last_updated(self, subpath=None):
         """


### PR DESCRIPTION
Changed the detection in DirectoryReader.is_binary to only return False if the file has a *text/* mime type, otherwise or if the mime type couldn't be detected assume binary.