### PR TITLE
Add options to remove borders and titles

### DIFF
--- a/grip/api.py
+++ b/grip/api.py
@@ -13,7 +13,8 @@ from .renderers import GitHubRenderer, OfflineRenderer
 def create_app(path=None, user_content=False, context=None, username=None,
                password=None, render_offline=False, render_wide=False,
                render_inline=False, api_url=None, title=None, text=None,
-               autorefresh=None, quiet=None, grip_class=None):
+               hide_border=False, hide_title=False, autorefresh=None, quiet=None,
+               grip_class=None):
     """
     Creates a Grip application with the specified overrides.
     """
@@ -43,20 +44,23 @@ def create_app(path=None, user_content=False, context=None, username=None,
 
     # Create the customized app with default asset manager
     return grip_class(source, auth, renderer, None, render_wide,
-                      render_inline, title, autorefresh, quiet)
+                      render_inline, title, hide_border, hide_title,
+                      autorefresh, quiet)
 
 
 def serve(path=None, host=None, port=None, user_content=False, context=None,
           username=None, password=None, render_offline=False,
           render_wide=False, render_inline=False, api_url=None, title=None,
-          autorefresh=True, browser=False, quiet=None, grip_class=None):
+          hide_border=False, hide_title=False, autorefresh=True, browser=False,
+          quiet=None, grip_class=None):
     """
     Starts a server to render the specified file or directory containing
     a README.
     """
     app = create_app(path, user_content, context, username, password,
                      render_offline, render_wide, render_inline, api_url,
-                     title, None, autorefresh, quiet, grip_class)
+                     title, None, hide_border, hide_title, autorefresh,
+                     quiet, grip_class)
     app.run(host, port, open_browser=browser)
 
 
@@ -72,13 +76,15 @@ def clear_cache(grip_class=None):
 def render_page(path=None, user_content=False, context=None,
                 username=None, password=None,
                 render_offline=False, render_wide=False, render_inline=False,
-                api_url=None, title=None, text=None, grip_class=None):
+                api_url=None, title=None, hide_border=False, hide_title=False,
+                text=None, grip_class=None):
     """
     Renders the specified markup text to an HTML page and returns it.
     """
     return create_app(path, user_content, context, username, password,
                       render_offline, render_wide, render_inline, api_url,
-                      title, text, False, None, grip_class).render()
+                      title, text, hide_border, hide_title, False, None,
+                      grip_class).render()
 
 
 def render_content(text, user_content=False, context=None, username=None,
@@ -96,7 +102,7 @@ def render_content(text, user_content=False, context=None, username=None,
 def export(path=None, user_content=False, context=None, username=None,
            password=None, render_offline=False, render_wide=False,
            render_inline=True, out_filename=None, api_url=None, title=None,
-           grip_class=None):
+           hide_border=False, hide_title=False, grip_class=None):
     """
     Exports the rendered HTML to a file.
     """
@@ -114,7 +120,7 @@ def export(path=None, user_content=False, context=None, username=None,
 
     page = render_page(path, user_content, context, username, password,
                        render_offline, render_wide, render_inline, api_url,
-                       title, None, grip_class)
+                       title, hide_border, hide_title, None, grip_class)
 
     if export_to_stdout:
         try:

--- a/grip/app.py
+++ b/grip/app.py
@@ -41,7 +41,8 @@ class Grip(Flask):
     containing a README.
     """
     def __init__(self, source=None, auth=None, renderer=None,
-                 assets=None, render_wide=None, render_inline=None, title=None,
+                 assets=None, render_wide=None, render_inline=None,
+                 title=None, hide_border=False, hide_title=False,
                  autorefresh=None, quiet=None, grip_url=None,
                  static_url_path=None, instance_path=None, **kwargs):
         # Defaults
@@ -99,6 +100,8 @@ class Grip(Flask):
         self.render_wide = render_wide
         self.render_inline = render_inline
         self.title = title
+        self.hide_border = hide_border
+        self.hide_title = hide_title
         self.quiet = quiet
         if self.quiet:
             import logging
@@ -189,7 +192,8 @@ class Grip(Flask):
 
         return render_template(
             'index.html', filename=self.reader.filename_for(subpath),
-            title=self.title, content=content, favicon=favicon,
+            title=self.title, hide_border=self.hide_border,
+            hide_title=self.hide_title, content=content, favicon=favicon,
             user_content=self.renderer.user_content,
             wide_style=self.render_wide, style_urls=self.assets.style_urls,
             styles=self.assets.styles, autorefresh_url=autorefresh_url)

--- a/grip/command.py
+++ b/grip/command.py
@@ -34,6 +34,9 @@ Options:
                     for example that of a Github Enterprise instance.
                     Default is the public API: https://api.github.com
   --title=<title>   Manually sets the page's title.
+  -B                Remove borders (currently not supported when running
+                    with --user-content).
+  -T                Remove title.
                     The default is the filename.
   --norefresh       Do not automatically refresh the Readme content when
                     the file changes.
@@ -107,7 +110,7 @@ def main(argv=None, force_utf8=True, patch_svg=True):
             export(args['<path>'], args['--user-content'], args['--context'],
                    args['--user'], password, False, args['--wide'],
                    not args['--no-inline'], args['<address>'],
-                   args['--api-url'], args['--title'])
+                   args['--api-url'], args['--title'], args['-B'], args['-T'])
             return 0
         except ReadmeNotFoundError as ex:
             print('Error:', ex)
@@ -125,8 +128,8 @@ def main(argv=None, force_utf8=True, patch_svg=True):
     try:
         serve(path, host, port, args['--user-content'], args['--context'],
               args['--user'], password, False, args['--wide'], False,
-              args['--api-url'], args['--title'], not args['--norefresh'],
-              args['--browser'], args['--quiet'], None)
+              args['--api-url'], args['--title'], args['-B'], args['-T'],
+              not args['--norefresh'], args['--browser'], args['--quiet'], None)
         return 0
     except ReadmeNotFoundError as ex:
         print('Error:', ex)

--- a/grip/templates/index.html
+++ b/grip/templates/index.html
@@ -108,13 +108,13 @@
         <div class="container new-discussion-timeline experiment-repo-nav">
           <div class="repository-content">
             <div id="readme" class="readme boxed-group clearfix announce instapaper_body md">
-              {% if not user_content and title or filename %}
-                <h3>
+              {% if not hide_title and (not user_content and title or filename) %}
+                <h3 {% if hide_border %}style="border:0px solid #ddd;"{% endif %}>
                   <span class="octicon octicon-book"></span>
                   {% if title %}{{ title }}{% else %}{{ filename }}{% endif %}
                 </h3>
               {% endif %}
-              <article class="markdown-body entry-content" itemprop="text" id="grip-content">
+              <article class="markdown-body entry-content" itemprop="text" id="grip-content" {% if hide_border %}style="border:0px solid #ddd;"{% endif %}>
                 {{ content|safe }}
               </article>
             </div>


### PR DESCRIPTION
The page looks better to print to a pdf when running with both options. The remove borders option ('-B') doesn't work with '--user-content', although it should be easy to make it work.