### PR TITLE
fix #238: "Exporting to foobar.html" no longer printed with --quiet and --export

### DIFF
--- a/grip/api.py
+++ b/grip/api.py
@@ -93,7 +93,7 @@ def render_content(text, user_content=False, context=None, username=None,
     return renderer.render(text, auth)
 
 
-def export(path=None, user_content=False, context=None, username=None,
+def export(path=None, quiet=False, user_content=False, context=None, username=None,
            password=None, render_offline=False, render_wide=False,
            render_inline=True, out_filename=None, api_url=None, title=None,
            grip_class=None):
@@ -109,7 +109,7 @@ def export(path=None, user_content=False, context=None, username=None,
                 os.path.relpath(DirectoryReader(path).root_filename))
             out_filename = '{0}.html'.format(filetitle)
 
-    if not export_to_stdout:
+    if not export_to_stdout and not quiet:
         print('Exporting to', out_filename, file=sys.stderr)
 
     page = render_page(path, user_content, context, username, password,

--- a/grip/command.py
+++ b/grip/command.py
@@ -104,7 +104,7 @@ def main(argv=None, force_utf8=True, patch_svg=True):
     # Export to a file instead of running a server
     if args['--export']:
         try:
-            export(args['<path>'], args['--user-content'], args['--context'],
+            export(args['<path>'], args['--quiet'], args['--user-content'], args['--context'],
                    args['--user'], password, False, args['--wide'],
                    not args['--no-inline'], args['<address>'],
                    args['--api-url'], args['--title'])


### PR DESCRIPTION
fixed issue #238 by passing the `--quiet` option through to the `export` function in `api.py`.