### PR TITLE
fix #243: parse and render YAML front matter from document

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ settings_local.py
 .DS_Store
 Desktop.ini
 Thumbs.db
+
+# IDE files
+.idea

--- a/grip/renderers.py
+++ b/grip/renderers.py
@@ -5,12 +5,15 @@ import sys
 from abc import ABCMeta, abstractmethod
 
 import requests
+
 try:
     import markdown
     from .vendor.mdx_urlize import UrlizeExtension
 except ImportError:
     markdown = None
     UrlizeExtension = None
+
+from tabulate import tabulate
 
 from .constants import DEFAULT_API_URL
 from .patcher import patch
@@ -22,6 +25,7 @@ class ReadmeRenderer(object):
     """
     Renders the Readme.
     """
+
     def __init__(self, user_content=None, context=None):
         if user_content is None:
             user_content = False
@@ -41,6 +45,7 @@ class GitHubRenderer(ReadmeRenderer):
     """
     Renders the specified Readme using the GitHub Markdown API.
     """
+
     def __init__(self, user_content=None, context=None, api_url=None,
                  raw=None):
         if api_url is None:
@@ -74,13 +79,22 @@ class GitHubRenderer(ReadmeRenderer):
             data = text.encode('utf-8')
             headers = {'content-type': 'text/x-markdown; charset=UTF-8'}
 
+        # parse YAML front matter
+        meta_headers, values, content = parse_front_matter(data.decode('utf-8'))
+        data = content.encode('utf-8')
+
         r = requests.post(url, headers=headers, data=data, auth=auth)
         r.raise_for_status()
 
         # FUTURE: Remove this once GitHub API properly handles Unicode markdown
         r.encoding = 'utf-8'
 
-        return r.text if self.raw else patch(r.text)
+        if values is not None:
+            return_text = tabulate([values], meta_headers, "html", stralign="center") + r.text
+        else:
+            return_text = r.text
+
+        return return_text if self.raw else patch(return_text)
 
 
 class OfflineRenderer(ReadmeRenderer):
@@ -89,6 +103,7 @@ class OfflineRenderer(ReadmeRenderer):
 
     Note: This is currently an incomplete feature.
     """
+
     def __init__(self, user_content=None, context=None):
         super(OfflineRenderer, self).__init__(user_content, context)
 
@@ -100,7 +115,12 @@ class OfflineRenderer(ReadmeRenderer):
             import markdown
         if UrlizeExtension is None:
             from .mdx_urlize import UrlizeExtension
-        return markdown.markdown(text, extensions=[
+
+        # parse YAML front matter
+        meta_headers, values, content = parse_front_matter(text)
+        text = content
+
+        return_no_front_matter = markdown.markdown(text, extensions=[
             'fenced_code',
             'codehilite(css_class=highlight)',
             'toc',
@@ -108,3 +128,24 @@ class OfflineRenderer(ReadmeRenderer):
             'sane_lists',
             UrlizeExtension(),
         ])
+        if values is not None:
+            return tabulate(values, meta_headers, "html", stralign="center") + return_no_front_matter
+        else:
+            return return_no_front_matter
+
+def parse_front_matter(text):
+    splittext = text.split('---\n', 2)
+    headers = []
+    values = []
+    if text.startswith('---\n') and len(splittext) == 3:
+        front = splittext[1]
+        for line in front.splitlines():
+            linesplit = line.split(':')
+            if len(linesplit) == 2:
+                headers.append(linesplit[0])
+                values.append(linesplit[1].replace('"', '').replace("'", ''))
+            else:
+                return None, None, text
+        return headers, values, splittext[2]
+    else:
+        return None, None, text

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 docopt>=0.4.0
 Flask>=0.10.1
 Markdown>=2.5.1
+tabulate>=0.8.1
 path-and-address>=2.0.1
 Pygments>=1.6
 requests>=2.4.1


### PR DESCRIPTION
fix for #243 

Now renders YAML front matter as a table, as Github does.