### PR TITLE
Clarify that this sends your markdown to GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Grip -- GitHub Readme Instant Preview
 Render local readme files before sending off to GitHub.
 
 Grip is a command-line server application written in Python that uses the
-[GitHub markdown API][markdown] to render a local readme file. The styles
-come directly from GitHub, so you'll know exactly how it will appear. Changes
-you make to the Readme will be instantly reflected in the browser without
+[GitHub markdown REST API][markdown] to render a local readme file. The styles
+and rendering come directly from GitHub, so you'll know exactly how it will appear.
+Changes you make to the Readme will be instantly reflected in the browser without
 requiring a page refresh.
 
 


### PR DESCRIPTION
The current wording allows for the misinterpretation that the rendering is being done locally.
"Github markdown API" could mean a library published by GitHub, and "The styles come directly from GitHub" could mean just the CSS stylesheet.
This should be corrected, because if misinterpreted this way it leads to 2 false assumptions:
- Your data is not being sent to a third party
- This will work offline

I know information later in the readme talks about API rate limits and such, but many people won't read past the Usage section (myself included apparently). I think in particular the repeated mentions of a "local readme file" gave me this mistaken impression.

I think mentioning REST and saying that the rendering is done by GitHub is sufficient, but there may be some other change that clarifies this better.