### PR TITLE
Add gitattributes for GitHub Linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/tests/output/*/*.html linguist-generated=true


### PR DESCRIPTION
[GitHub Linguist](https://github.com/github/linguist) would classify the test HTML files as code, concluding that the whole project is written mostly in HTML:
> 1. HTML 73.1%
> 2. Python 26.9% 

This PR makes GitHub Linguist ignore the test HTML files, which makes the statistics way more helpful:
> 1. Python 90.2%
> 2. HTML 9.8% 