### PR TITLE
Distribute license file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+include LICENSE
 include *.txt
 include *.md
 recursive-include static *


### PR DESCRIPTION
To fulfill the specification of the MIT license, include it in the source distribution. 