### PR TITLE
Drop support for Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Grip Changelog
 #### Development
 
 - **Breaking change**: Drop Python 2.6 support
+- **Breaking change**: Drop Python 3.3 support
 
 - Tests: Add Python 3.6 support
 


### PR DESCRIPTION
Python 3.3 has reached end-of-life: https://devguide.python.org/#status-of-python-branches (2017-09-29)