### PR TITLE
Change errors to say README.md

### DIFF
--- a/grip/exceptions.py
+++ b/grip/exceptions.py
@@ -17,7 +17,7 @@ class ReadmeNotFoundError(NotFoundError):
         self.path = path
         self.message = message
         super(ReadmeNotFoundError, self).__init__(
-            errno.ENOENT, 'README not found', path)
+            errno.ENOENT, 'README.md not found', path)
 
     def __repr__(self):
         return '{0}({!r}, {!r})'.format(
@@ -28,6 +28,6 @@ class ReadmeNotFoundError(NotFoundError):
             return self.message
 
         if self.path is not None:
-            return 'No README found at {0}'.format(self.path)
+            return 'No README.md found at {0}'.format(self.path)
 
         return self.strerror

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -45,8 +45,8 @@ def test_exceptions():
     Test that ReadmeNotFoundError behaves like FileNotFoundError on
     Python 3 and IOError on Python 2.
     """
-    assert str(ReadmeNotFoundError()) == 'README not found'
-    assert (str(ReadmeNotFoundError('.')) == 'No README found at .')
+    assert str(ReadmeNotFoundError()) == 'README.md not found'
+    assert (str(ReadmeNotFoundError('.')) == 'No README.md found at .')
     assert str(ReadmeNotFoundError('some/path', 'Overridden')) == 'Overridden'
     assert ReadmeNotFoundError().filename is None
     assert ReadmeNotFoundError(DEFAULT_FILENAME).filename == DEFAULT_FILENAME


### PR DESCRIPTION
If you run grip in a project with a README file (rather than README.md), it will tell you `Error: No README found at .`  This updates the error message to README.md to match the file grip is actually trying to read.
