### PR TITLE
Add support for the XDG Base Directory Specification.

### DIFF
--- a/grip/app.py
+++ b/grip/app.py
@@ -63,7 +63,10 @@ class Grip(Flask):
         if instance_path is None:
             instance_path = os.environ.get('GRIPHOME')
             if instance_path is None:
-                instance_path = DEFAULT_GRIPHOME
+                instance_path = os.path.expanduser(DEFAULT_GRIPHOME)
+                if not os.path.exists(instance_path):
+                    instance_path = os.environ.get('XDG_CONFIG_HOME', '~/.config')
+                    instance_path = os.path.join(instance_path, 'grip')
         instance_path = os.path.abspath(os.path.expanduser(instance_path))
 
         # Flask application
@@ -353,7 +356,9 @@ class Grip(Flask):
         cache_directory = self.config['CACHE_DIRECTORY']
         if cache_directory:
             cache_directory = cache_directory.format(version=__version__)
-            cache_path = os.path.join(self.instance_path, cache_directory)
+            cache_path = os.environ.get('XDG_CACHE_HOME', '~/.cache')
+            cache_path = os.path.abspath(os.path.expanduser(cache_path))
+            cache_path = os.path.join(cache_path, 'grip', cache_directory)
         return GitHubAssetManager(
             cache_path, self.config['STYLE_URLS'], self.quiet)
 

--- a/grip/settings.py
+++ b/grip/settings.py
@@ -3,7 +3,10 @@ Default Configuration
 
 Do NOT change the values here for risk of accidentally committing them.
 Override them using command-line arguments or with a settings_local.py in
-this directory or in ~/.grip/settings.py instead.
+this directory or in one of the following (in order of precedence):
+ 1. "${GRIPHOME}/settings.py" (if GRIPHOME is set)
+ 2. "~/.grip/settings.py" (if "~/.grip" exists)
+ 3. "${XDG_CONFIG_HOME:-~/.config}/grip/settings.py" (fallback)
 """
 
 


### PR DESCRIPTION
Hey @joeyespo. 

This is a fix for #286. We adopt the solution as given by the table in this [comment](https://github.com/joeyespo/grip/issues/286#issuecomment-460775212). The order of precedence is:

1. `${GRIPHOME}/settings.py` (if `GRIPHOME` is set)
2. `~/.grip/settings.py` (if `~/.grip` exists)
3. `${XDG_CONFIG_HOME:-~/.config}/grip/settings.py` (fallback)

Also, the cache files are in `${XDG_CACHE_HOME:-~/.cache}/grip`. I believe these files are not important at all for the user, hence I decided to not have a migration path for them.

Feel free to comment whatever you want about this.