### PR TITLE
Encode output HTML as 'utf-8' when writing to stdout.

### DIFF
--- a/grip/api.py
+++ b/grip/api.py
@@ -119,7 +119,7 @@ def export(path=None, user_content=False, context=None,
 
     if export_to_stdout:
         try:
-            print(page)
+            print(page.encode('utf-8'))
         except IOError as ex:
             if ex.errno != 0 and ex.errno != errno.EPIPE:
                 raise


### PR DESCRIPTION
Encode HTML output as 'utf-8' when writing to stdout, so grip
works also in case LANG=C or other non-UTF-8 LANG settings.