### PR TITLE
True up templates to CSS (fixes #291).

### DIFF
--- a/grip/templates/index.html
+++ b/grip/templates/index.html
@@ -100,23 +100,28 @@
 {%- endblock -%}
 
 {%- block page -%}
-  <div id="preview-page" class="preview-page" data-autorefresh-url="{{ autorefresh_url if autorefresh_url }}">
+  <div>&nbsp;</div>
+  <div id="preview-page" data-autorefresh-url="{{ autorefresh_url if autorefresh_url }}">
 
     {% if not user_content %}
 
       <div role="main" class="main-content">
-        <div class="container new-discussion-timeline experiment-repo-nav">
+        <div class="container-lg new-discussion-timeline experiment-repo-nav">
           <div class="repository-content">
-            <div id="readme" class="readme boxed-group clearfix announce instapaper_body md">
-              {% if not user_content and title or filename %}
-                <h3>
-                  <span class="octicon octicon-book"></span>
-                  {% if title %}{{ title }}{% else %}{{ filename }}{% endif %}
-                </h3>
-              {% endif %}
-              <article class="markdown-body entry-content" itemprop="text" id="grip-content">
-                {{ content|safe }}
-              </article>
+            <div class="Box mt-3 position-relative">
+                {% if not user_content and title or filename %}
+                  <div class="commit-tease d-flex rounded-top-1" style="border: 0; border-bottom: 1px solid #c8e1ff;">
+                    <h5>
+                      <span class="octicon octicon-book"></span>
+                      {% if title %}{{ title }}{% else %}{{ filename }}{% endif %}
+                    </h5>
+                  </div>
+                {% endif %}
+              <div id="readme" class="Box-body readme blob instapaper_body js-code-block-container">
+                <article id="grip-content" class="markdown-body entry-content p-3 p-md-6" itemprop="text">
+                  {{ content|safe }}
+                </article>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
👋 Hey there! I happened to stumble over the selector drift nuisance in #291, and figured I'd take a crack at fixing it. The changes turned out to be pretty minor, unless I'm missing something.

Still need to clean up the test suite and do a visual audit of the `user_content` styling, but figured I'd throw a quick fix up in case anyone else gets bit.

Thanks for all your work on Grip! Don't know how anyone can stand the lesser GFM styles out there.

#### BEFORE
![localhost_6419_ (1)](https://user-images.githubusercontent.com/2207980/57963910-c80d1080-78f9-11e9-93a1-8a9a456afb0f.png)

#### AFTER
![localhost_6419_](https://user-images.githubusercontent.com/2207980/57963912-cba09780-78f9-11e9-8735-23d72ef1d30c.png)

#### TODO
- [ ] Fix tests.
- [ ] Audit `user_content` styles.