### PR TITLE
Add Python 3.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - 3.4
   - 3.5
   - 3.6
+  - 3.7
   - pypy
   - pypy3
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
-sudo: false
+dist: xenial
 language: python
 python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
-  - "3.6"
-  - "pypy"
-  - "pypy3"
+  - 2.7
+  - 3.4
+  - 3.5
+  - 3.6
+  - pypy
+  - pypy3
 install:
   - pip install -e .[tests]
 script:


### PR DESCRIPTION
Note that this required upgrading Travis CI's dist to `xenial`.

References:
- https://docs.travis-ci.com/user/reference/xenial/
- https://docs.travis-ci.com/user/languages/python/#python-37-and-higher
- https://docs.travis-ci.com/user/reference/overview/#deprecated-virtualization-environments
