### PR TITLE
Disable ssl verification

### DIFF
--- a/grip/app.py
+++ b/grip/app.py
@@ -277,7 +277,7 @@ class Grip(Flask):
 
     def _download(self, url, binary=False):
         if urlparse(url).netloc:
-            r = requests.get(url)
+            r = requests.get(url, verify=False)
             return r.content if binary else r.text
 
         with self.test_client() as c:

--- a/grip/assets.py
+++ b/grip/assets.py
@@ -84,7 +84,7 @@ class GitHubAssetManager(ReadmeAssetManager):
                 return cached
 
         # Find style URLs
-        r = requests.get(STYLE_URLS_SOURCE)
+        r = requests.get(STYLE_URLS_SOURCE, verify=False)
         if not 200 <= r.status_code < 300:
             print('Warning: retrieving styles gave status code',
                   r.status_code, file=sys.stderr)
@@ -130,7 +130,7 @@ class GitHubAssetManager(ReadmeAssetManager):
         for style_url in style_urls:
             if not self.quiet:
                 print(' * Downloading style', style_url, file=sys.stderr)
-            r = requests.get(style_url)
+            r = requests.get(style_url, verify=False)
             if not 200 <= r.status_code < 300:
                 print(' -> Warning: Style request responded with',
                       r.status_code, file=sys.stderr)
@@ -153,7 +153,7 @@ class GitHubAssetManager(ReadmeAssetManager):
             if not self.quiet:
                 print(' * Downloading asset', asset_url, file=sys.stderr)
             # Retrieve binary file and show message
-            r = requests.get(asset_url, stream=True)
+            r = requests.get(asset_url, stream=True, verify=False)
             if not 200 <= r.status_code < 300:
                 print(' -> Warning: Asset request responded with',
                       r.status_code, file=sys.stderr)


### PR DESCRIPTION
Set `verify=False` everywhere.

I live in a strict VPN world and I need this for assets to load through our self-signed CA cert.

This is ham fisted and I apologize for tossing up a not-very-well-reasoned PR. It works for me so I submit it for your scrutiny.

A better option to blindly ignoring ssl issues would be to provide an arg to pass in a custom cacert.

Related to #248 