### PR TITLE
Add GitLabRenderer

### DIFF
--- a/grip/constants.py
+++ b/grip/constants.py
@@ -22,6 +22,9 @@ DEFAULT_GRIPURL = '/__/grip'
 # The public GitHub API
 DEFAULT_API_URL = 'https://api.github.com'
 
+# The public GitLab API
+DEFAULT_GITLAB_API_URL = 'https://gitlab.com'
+
 
 # Style parsing
 STYLE_URLS_SOURCE = 'https://github.com/joeyespo/grip'


### PR DESCRIPTION
An initial attempt at creating a renderer using the GitLab API. Authentication has not yet been implemented, so the `--context` option can only be used with public repositories.

This is mainly meant as some initial work to see if there is interest in the feature. I assume the next steps would be to implement some sort of `--renderer` options to enable the `GitLabRenderer`, add support for authentication, and tests.