### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3
+
+COPY ./requirements.txt /usr/src/app/
+WORKDIR /usr/src/app/
+RUN pip install --no-cache-dir -r ./requirements.txt
+
+COPY . /usr/src/app/
+RUN pip install --no-cache-dir .
+
+ENTRYPOINT [ "grip" ]


### PR DESCRIPTION
Thank you very much for this awesome piece of software. As I've started to tinker with it, I'd like to share the Dockerfile which enabled a Docker workflow for me.

Add Dockerfile to enable image building. Useful for development and tests under Docker workflow.
Using the official Python 3 image, latest tag. More info at https://hub.docker.com/_/python/
 
Just adding files, setting working dir and running install and build instructions. `requirements.txt` is added and `pip install`'ed in a separate step to speed up rebuilds, since it will take advantage of Docker image build layer caching on subsequent builds after modifying code.
 
Build:
 
```
$ docker build -t grip .
```
 
Run:
 
```
$ docker run --rm -it -v ${PWD}:/grip/ -p 6419:6419 grip [options...] /grip/ 0.0.0.0
```
 
FYI, there's a still quicker to test, already built image on my Docker Hub. Test it by running:
 
```
$ docker run --rm -it -v ${PWD}:/grip/ -p 6419:6419 pataquets/grip-src [options...] /grip/ 0.0.0.0
```

The examples mount the current dir inside the Docker container (`-v`) and map container's internal  port to outside host (`p`). Adding `0.0.0.0` is required, since otherwise container's `localhost` would not be reachable from outside (the host). 
Using `--rm` causes container it to be deleted after stop and `-it` makes the container not to go background and run interactively. Stop by `CTRL+C`'ing.

Optional improvement to come (maybe in another issue):
- Create an 'official', based on your repo, automated build at Docker Hub for the image: https://docs.docker.com/docker-hub/builds/ . Just requires a free Docker Hub account and a following a quick 'Create automated build' process. I'll be happy to help on it, if needed.