### PR TITLE
fix: scrollToHash get anchor by name

### DIFF
--- a/grip/templates/index.html
+++ b/grip/templates/index.html
@@ -49,9 +49,9 @@
 
     function scrollToHash() {
       if (location.hash && !document.querySelector(':target')) {
-        var element = document.getElementById('user-content-' + location.hash.slice(1));
-        if (element) {
-           element.scrollIntoView();
+        var elements = document.getElementsByName('user-content-' + location.hash.slice(1));
+        if (elements.length) {
+           elements[0].scrollIntoView();
         }
       }
     }


### PR DESCRIPTION
```html
<p><a name="user-content-debug.proto"></a></p>
<p align="right"><a href="#top">Top</a></p>
<h2>
<a id="user-content-debugproto" class="anchor" href="#debugproto" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>debug.proto</h2>
```
This is my exported index.html. `id`s of \<a> tags including headers don't have `.`(period), but `name`s of \<a> tags in \<p> above headers have original reference with `.`.

When a header had periods or anything IDK in their name, Its link is broken.

So I fixed it to use anchors with the name instead of anchors with id including header tag. I think this is why `<p><a  name="..."></a></p>` is exists.