### PR TITLE
Fixing flake8 error

### DIFF
--- a/grip/exceptions.py
+++ b/grip/exceptions.py
@@ -20,7 +20,7 @@ class ReadmeNotFoundError(NotFoundError):
             errno.ENOENT, 'README not found', path)
 
     def __repr__(self):
-        return '{0}({!r}, {!r})'.format(
+        return '{}({!r}, {!r})'.format(
             type(self).__name__, self.path, self.message)
 
     def __str__(self):


### PR DESCRIPTION
Hi

Travis CI was failing with :-
`F525 '...'.format(...) mixes automatic and manual numbering`

Since index is not necessary, can be removed to make flake8 compliant. Please review.

Thanks