### PR TITLE
Add a status indicator, clean up the default header

### DIFF
--- a/grip/app.py
+++ b/grip/app.py
@@ -229,6 +229,7 @@ class Grip(Flask):
 
         def gen():
             last_updated = self.reader.last_updated(subpath)
+            yield ': started\r\n\r\n'
             try:
                 while not shutdown_event.is_set():
                     time.sleep(0.3)

--- a/grip/templates/index.html
+++ b/grip/templates/index.html
@@ -25,6 +25,38 @@
       top: -1em;
       color: #666;
     }
+    #grip-status-indicator.grip-floating-indicator {
+      position: relative;
+      top: calc(0.75em + 15px);
+      right: 15px;
+      color: #666;
+    }
+    #grip-status-indicator {
+      float: right;
+      text-transform: uppercase;
+      cursor: default;
+      -webkit-user-select: none;
+      user-select: none;
+      font-weight: bold;
+      --yellow: #FFDC00;
+      --red: #FF4136;
+      --green: #2ECC40;
+    }
+    #grip-status-indicator::after {
+      content: "";
+      display: inline-block;
+      width: 0.85em;
+      height: 0.85em;
+      background: var(--color);
+      border-radius: 50%;
+      vertical-align: middle;
+      position: relative;
+      bottom: 1.5px;
+      margin-left: 0.5em;
+    }
+    #grip-status-indicator + #grip-content > :first-child {
+      margin-top: 0;
+    }
     /* User-content tweaks */
     .timeline-comment-wrapper {
       padding-left: 0;
@@ -73,13 +105,27 @@
       var source = new EventSource(eventSourceUrl);
       var isRendering = false;
 
+      var statusElement = document.getElementById('grip-status-indicator');
+      statusElement.hidden = false;
+      statusElement.textContent = 'Connecting';
+      statusElement.style.setProperty('--color', 'var(--yellow)');
+
+      source.onopen = function() {
+        statusElement.textContent = 'Connected';
+        statusElement.style.setProperty('--color', 'var(--green)');
+      }
+
       source.onmessage = function(ev) {
         var msg = JSON.parse(ev.data);
         if (msg.updating) {
           isRendering = true;
+          statusElement.textContent = 'Updating';
+          statusElement.style.setProperty('--color', 'var(--yellow)');
           document.title = '(Rendering) ' + document.title;
         } else {
           isRendering = false;
+          statusElement.textContent = 'Connected';
+          statusElement.style.setProperty('--color', 'var(--green)');
           document.title = initialTitle;
           contentElement.innerHTML = msg.content;
           showCanonicalImages();
@@ -91,6 +137,8 @@
           isRendering = false;
           document.title = initialTitle;
         }
+        statusElement.textContent = 'Disconnected';
+        statusElement.style.setProperty('--color', 'var(--red)');
       }
     }
 
@@ -123,6 +171,7 @@
                 <h3 id="grip-readme-header" class="Box-title px-5">
                   <span class="octicon octicon-book"></span>
                   {{ title or filename }}
+                  <span id="grip-status-indicator" hidden style="--color: var(--yellow)">Connecting</span>
                 </h3>
             {% endif %}
 
@@ -146,10 +195,14 @@
                               <div class="timeline-comment-header clearfix">
                                 <h3 class="timeline-comment-header-text f5 text-normal">
                                   <strong class="css-truncate expandable"><span class="author text-inherit css-truncate-target">{{ title }}</span></strong>
+                                  <span id="grip-status-indicator" hidden style="--color: var(--yellow)">Connecting</span>
                                 </h3>
                               </div>
                             {% endif %}
                             <div class="edit-comment-hide">
+                              {% if not title %}
+                                <span id="grip-status-indicator" class="grip-floating-indicator" hidden style="--color: var(--yellow)">Connecting</span>
+                              {% endif %}
                               <div class="d-block comment-body markdown-body js-comment-body" id="grip-content">
                                 {{ content|safe }}
                               </div>

--- a/grip/templates/index.html
+++ b/grip/templates/index.html
@@ -26,9 +26,7 @@
       color: #666;
     }
     #grip-status-indicator.grip-floating-indicator {
-      position: relative;
-      top: calc(0.75em + 15px);
-      right: calc(0.5em + 15px);
+      margin: calc(0.5em + 15px);
       color: #666;
     }
     #grip-status-indicator {

--- a/grip/templates/index.html
+++ b/grip/templates/index.html
@@ -26,9 +26,15 @@
       color: #666;
     }
     /* User-content tweaks */
+    .timeline-comment-wrapper {
+      padding-left: 0;
+    }
     .timeline-comment-wrapper > .timeline-comment:after,
     .timeline-comment-wrapper > .timeline-comment:before {
       content: none;
+    }
+    .discussion-timeline {
+      float: none;
     }
     /* User-content overrides */
     .discussion-timeline.wide {

--- a/grip/templates/index.html
+++ b/grip/templates/index.html
@@ -20,6 +20,11 @@
       margin-top: 64px;
       margin-bottom: 21px;
     }
+    #grip-readme-header {
+      position: relative;
+      top: -1em;
+      color: #666;
+    }
     /* User-content tweaks */
     .timeline-comment-wrapper > .timeline-comment:after,
     .timeline-comment-wrapper > .timeline-comment:before {
@@ -108,20 +113,17 @@
 
           {% if not user_content %}
 
-            <div id="readme" class="Box Box--condensed instapaper_body md js-code-block-container">
-              {% if title or filename %}
-                <div class="Box-header d-flex flex-items-center flex-justify-between px-2">
-                  <h3 class="Box-title pr-3">
-                    <span class="octicon octicon-book"></span>
-                    {{ title or filename }}
-                  </h3>
-                </div>
-              {% endif %}
-              <div class="Box-body">
-                <article id="grip-content" class="markdown-body entry-content p-5" itemprop="text">
-                  {{ content|safe }}
-                </article>
-              </div>
+            {% if title or filename %}
+                <h3 id="grip-readme-header" class="Box-title px-5">
+                  <span class="octicon octicon-book"></span>
+                  {{ title or filename }}
+                </h3>
+            {% endif %}
+
+            <div id="readme" class="instapaper_body md js-code-block-container">
+              <article id="grip-content" class="markdown-body entry-content p-5" itemprop="text">
+                {{ content|safe }}
+              </article>
             </div>
 
           {% else %}

--- a/grip/templates/index.html
+++ b/grip/templates/index.html
@@ -28,7 +28,7 @@
     #grip-status-indicator.grip-floating-indicator {
       position: relative;
       top: calc(0.75em + 15px);
-      right: 15px;
+      right: calc(0.5em + 15px);
       color: #666;
     }
     #grip-status-indicator {

--- a/grip/templates/index.html
+++ b/grip/templates/index.html
@@ -81,7 +81,7 @@
       }
 
       source.onerror = function(e) {
-        if (e.readyState === EventSource.CLOSED && isRendering) {
+        if (isRendering) {
           isRendering = false;
           document.title = initialTitle;
         }


### PR DESCRIPTION
- Update the default header to de-emphasize it
- Adds a status indicator (if `--norefresh` is not passed) that displays the status of the `EventSource`
- Indicator colors are from [clrs.cc](https://clrs.cc), but could be changed to any other colors

Representative screenshots:

<img width="600" alt="Screenshot_2021-02-21 14 56 26" src="https://user-images.githubusercontent.com/25517624/108637126-38de4680-7457-11eb-928b-c30c1c8924ed.png">
<img width="600" alt="Screenshot_2021-02-21 14 58 21" src="https://user-images.githubusercontent.com/25517624/108637123-354abf80-7457-11eb-8cfa-7c082001afce.png">
<img width="600" alt="Screenshot_2021-02-21 14 56 40" src="https://user-images.githubusercontent.com/25517624/108637136-4693cc00-7457-11eb-86dc-0ebe280c6c82.png">
<img width="600" alt="Screenshot_2021-02-21 15 14 19" src="https://user-images.githubusercontent.com/25517624/108637171-80fd6900-7457-11eb-835a-6bcbae4d424c.png">
<img width="600" alt="Screenshot_2021-02-21 15 02 35" src="https://user-images.githubusercontent.com/25517624/108637180-8bb7fe00-7457-11eb-8271-6934eac2ba20.png">
<img width="600" alt="Screenshot_2021-02-21 15 16 41" src="https://user-images.githubusercontent.com/25517624/108637258-d5a0e400-7457-11eb-847e-374337a93f1a.png">
