### PR TITLE
Add theme support

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,19 @@ Grip always accesses GitHub over HTTPS,
 so your README and credentials are protected.
 
 
+Theming
+-------
+
+Grip supports the three standard GitHub themes: `Light`, `Dark`, and `Dark dimmed`.
+By default Grip uses the `Light` theme. You can change the default theme
+in the [config file](#configuration) by setting the `THEME` variable.
+Valid values are `light`, `dark`, and `dark_dimmed` (all lowercase).
+
+You can also dynamically set the theme of non-user content within the generated web page.
+At the right of the title banner at the top is a “Theme” menu which can be used to
+change the theme.
+
+
 Tips
 ----
 
@@ -246,8 +259,9 @@ To customize Grip, create `~/.grip/settings.py`, then add one or more of the fol
 - `API_URL`: Base URL for the github API, for example that of a Github Enterprise instance. `https://api.github.com` by default
 - `CACHE_DIRECTORY`: The directory, relative to `~/.grip`, to place cached assets (this gets run through the following filter: `CACHE_DIRECTORY.format(version=__version__)`), `'cache-{version}'` by default
 - `AUTOREFRESH`: Whether to automatically refresh the Readme content when the file changes, `True` by default
-- `QUIET`: Do not print extended information, `False` by default
 - `STYLE_URLS`: Additional URLs that will be added to the rendered page, `[]` by default
+- `QUIET`: Do not print extended information, `False` by default
+- `THEME`: The theme to use, `'light'` by default. Valid values are `'light'`, `'dark'` and `'dark_dimmed'`.
 - `USERNAME`: The username to use when not provided as a CLI argument, `None` by default
 - `PASSWORD`: The password or [personal access token][] to use when not provided as a CLI argument (*Please don't save your passwords here.* Instead, use an access token or drop in this code [grab your password from a password manager][keychain-access]), `None` by default
 
@@ -316,7 +330,7 @@ Runs a local server and renders the Readme file located
 at `path` when visited in the browser.
 
 ```python
-serve(path=None, host=None, port=None, user_content=False, context=None, username=None, password=None, render_offline=False, render_wide=False, render_inline=False, api_url=None, title=None, autorefresh=True, browser=False, grip_class=None)
+serve(path=None, host=None, port=None, user_content=False, context=None, username=None, password=None, render_offline=False, render_wide=False, render_inline=False, api_url=None, title=None, autorefresh=True, browser=False, theme=None, quiet=None, grip_class=None)
 ```
 
 - `path`: The filename to render, or the directory containing your Readme file, defaulting to the current working directory
@@ -333,7 +347,9 @@ serve(path=None, host=None, port=None, user_content=False, context=None, usernam
 - `api_url`: A different base URL for the github API, for example that of a Github Enterprise instance. The default is the public API https://api.github.com.
 - `title`: The page title, derived from `path` by default
 - `autorefresh`: Automatically update the rendered content when the Readme file changes, `True` by default
-- `browser`: Open a tab in the browser after the server starts., `False` by default
+- `browser`: Open a tab in the browser after the server starts, `False` by default
+- `theme`: The theme to use, `'light'` by default
+- `quiet`: Suppress logging to the terminal (except error messages), `False` by default
 - `grip_class`: Use a custom [Grip class](#class-gripflask)
 
 
@@ -342,7 +358,7 @@ serve(path=None, host=None, port=None, user_content=False, context=None, usernam
 Writes the specified Readme file to an HTML file with styles and assets inlined.
 
 ```python
-export(path=None, user_content=False, context=None, username=None, password=None, render_offline=False, render_wide=False, render_inline=True, out_filename=None, api_url=None, title=None, quiet=None, grip_class=None)
+export(path=None, user_content=False, context=None, username=None, password=None, render_offline=False, render_wide=False, render_inline=True, out_filename=None, api_url=None, title=None, theme=None, quiet=False, grip_class=None)
 ```
 
 - `path`: The filename to render, or the directory containing your Readme file, defaulting to the current working directory
@@ -357,7 +373,8 @@ export(path=None, user_content=False, context=None, username=None, password=None
 - `out_filename`: The filename to write to, `<in_filename>.html` by default
 - `api_url`: A different base URL for the github API, for example that of a Github Enterprise instance. The default is the public API https://api.github.com.
 - `title`: The page title, derived from `path` by default
-- `quiet`: Do not print to the terminal
+- `theme`: The theme to use, `'light'` by default
+- `quiet`: Suppress logging to the terminal (except error messages), `False` by default
 - `grip_class`: Use a custom [Grip class](#class-gripflask)
 
 
@@ -368,7 +385,7 @@ This is the same app used by `serve` and `export` and initializes the cache,
 using the cached styles when available.
 
 ```python
-create_app(path=None, user_content=False, context=None, username=None, password=None, render_offline=False, render_wide=False, render_inline=False, api_url=None, title=None, text=None, grip_class=None)
+create_app(path=None, user_content=False, context=None, username=None, password=None, render_offline=False, render_wide=False, render_inline=False, api_url=None, title=None, text=None, theme=None, quiet=False, grip_class=None)
 ```
 
 - `path`: The filename to render, or the directory containing your Readme file, defaulting to the current working directory
@@ -383,6 +400,8 @@ create_app(path=None, user_content=False, context=None, username=None, password=
 - `api_url`: A different base URL for the github API, for example that of a Github Enterprise instance. The default is the public API https://api.github.com.
 - `title`: The page title, derived from `path` by default
 - `text`: A string or stream of Markdown text to render instead of being loaded from `path` (Note: `path` can be used to set the page title)
+- `theme`: The theme to use, `'light'` by default
+- `quiet`: Suppress logging to the terminal (except error messages), `False` by default
 - `grip_class`: Use a custom [Grip class](#class-gripflask)
 
 
@@ -424,7 +443,7 @@ Renders the markdown from the specified path or text, without caching,
 and returns an HTML page that resembles the GitHub Readme view.
 
 ```python
-render_page(path=None, user_content=False, context=None, username=None, password=None, render_offline=False, render_wide=False, render_inline=False, api_url=None, title=None, text=None, quiet=None, grip_class=None)
+render_page(path=None, user_content=False, context=None, username=None, password=None, render_offline=False, render_wide=False, render_inline=False, api_url=None, title=None, text=None, theme=None, quiet=None, grip_class=None)
 ```
 
 - `path`: The path to use for the page title, rendering `'README.md'` if None
@@ -439,7 +458,8 @@ render_page(path=None, user_content=False, context=None, username=None, password
 - `api_url`: A different base URL for the github API, for example that of a Github Enterprise instance. The default is the public API https://api.github.com.
 - `title`: The page title, derived from `path` by default
 - `text`: A string or stream of Markdown text to render instead of being loaded from `path` (Note: `path` can be used to set the page title)
-- `quiet`: Do not print to the terminal
+- `theme`: The theme to use, `'light'` by default
+- `quiet`: Suppress logging to the terminal (except error messages), `False` by default
 - `grip_class`: Use a custom [Grip class](#class-gripflask)
 
 

--- a/README.md
+++ b/README.md
@@ -186,11 +186,15 @@ Theming
 -------
 
 Grip supports the three standard GitHub themes: `Light`, `Dark`, and `Dark dimmed`.
-By default Grip uses the `Light` theme. You can change the default theme
-in the [config file](#configuration) by setting the `THEME` variable.
-Valid values are `light`, `dark`, and `dark_dimmed` (all lowercase).
+By default Grip uses the `Light` theme. You can change the theme in several ways;
+note that the valid theme values are `light`, `dark`, and `dark_dimmed` (all lowercase).
 
-You can also dynamically set the theme of non-user content within the generated web page.
+- **Configuration** — You can change the default theme in the [config file](#configuration)
+  by setting the `THEME` variable.
+
+- **CLI** — You can set the theme by running `grip --theme=<theme>` on the command line.
+
+- **Live** — You can dynamically set the theme of non-user content within the generated web page.
 At the right of the title banner at the top is a “Theme” menu which can be used to
 change the theme.
 
@@ -330,7 +334,7 @@ Runs a local server and renders the Readme file located
 at `path` when visited in the browser.
 
 ```python
-serve(path=None, host=None, port=None, user_content=False, context=None, username=None, password=None, render_offline=False, render_wide=False, render_inline=False, api_url=None, title=None, autorefresh=True, browser=False, theme=None, quiet=None, grip_class=None)
+serve(path=None, host=None, port=None, user_content=False, context=None, username=None, password=None, render_offline=False, render_wide=False, render_inline=False, api_url=None, title=None, autorefresh=True, browser=False, quiet=None, theme=None, grip_class=None)
 ```
 
 - `path`: The filename to render, or the directory containing your Readme file, defaulting to the current working directory
@@ -348,8 +352,8 @@ serve(path=None, host=None, port=None, user_content=False, context=None, usernam
 - `title`: The page title, derived from `path` by default
 - `autorefresh`: Automatically update the rendered content when the Readme file changes, `True` by default
 - `browser`: Open a tab in the browser after the server starts, `False` by default
-- `theme`: The theme to use, `'light'` by default
 - `quiet`: Suppress logging to the terminal (except error messages), `False` by default
+- `theme`: The theme to use, `'light'` by default
 - `grip_class`: Use a custom [Grip class](#class-gripflask)
 
 
@@ -358,7 +362,7 @@ serve(path=None, host=None, port=None, user_content=False, context=None, usernam
 Writes the specified Readme file to an HTML file with styles and assets inlined.
 
 ```python
-export(path=None, user_content=False, context=None, username=None, password=None, render_offline=False, render_wide=False, render_inline=True, out_filename=None, api_url=None, title=None, theme=None, quiet=False, grip_class=None)
+export(path=None, user_content=False, context=None, username=None, password=None, render_offline=False, render_wide=False, render_inline=True, out_filename=None, api_url=None, title=None, quiet=False, theme=None, grip_class=None)
 ```
 
 - `path`: The filename to render, or the directory containing your Readme file, defaulting to the current working directory
@@ -373,8 +377,8 @@ export(path=None, user_content=False, context=None, username=None, password=None
 - `out_filename`: The filename to write to, `<in_filename>.html` by default
 - `api_url`: A different base URL for the github API, for example that of a Github Enterprise instance. The default is the public API https://api.github.com.
 - `title`: The page title, derived from `path` by default
-- `theme`: The theme to use, `'light'` by default
 - `quiet`: Suppress logging to the terminal (except error messages), `False` by default
+- `theme`: The theme to use, `'light'` by default
 - `grip_class`: Use a custom [Grip class](#class-gripflask)
 
 
@@ -385,7 +389,7 @@ This is the same app used by `serve` and `export` and initializes the cache,
 using the cached styles when available.
 
 ```python
-create_app(path=None, user_content=False, context=None, username=None, password=None, render_offline=False, render_wide=False, render_inline=False, api_url=None, title=None, text=None, theme=None, quiet=False, grip_class=None)
+create_app(path=None, user_content=False, context=None, username=None, password=None, render_offline=False, render_wide=False, render_inline=False, api_url=None, title=None, text=None, quiet=False, theme=None, grip_class=None)
 ```
 
 - `path`: The filename to render, or the directory containing your Readme file, defaulting to the current working directory
@@ -400,8 +404,8 @@ create_app(path=None, user_content=False, context=None, username=None, password=
 - `api_url`: A different base URL for the github API, for example that of a Github Enterprise instance. The default is the public API https://api.github.com.
 - `title`: The page title, derived from `path` by default
 - `text`: A string or stream of Markdown text to render instead of being loaded from `path` (Note: `path` can be used to set the page title)
-- `theme`: The theme to use, `'light'` by default
 - `quiet`: Suppress logging to the terminal (except error messages), `False` by default
+- `theme`: The theme to use, `'light'` by default
 - `grip_class`: Use a custom [Grip class](#class-gripflask)
 
 
@@ -443,7 +447,7 @@ Renders the markdown from the specified path or text, without caching,
 and returns an HTML page that resembles the GitHub Readme view.
 
 ```python
-render_page(path=None, user_content=False, context=None, username=None, password=None, render_offline=False, render_wide=False, render_inline=False, api_url=None, title=None, text=None, theme=None, quiet=None, grip_class=None)
+render_page(path=None, user_content=False, context=None, username=None, password=None, render_offline=False, render_wide=False, render_inline=False, api_url=None, title=None, text=None, quiet=None, theme=None, grip_class=None)
 ```
 
 - `path`: The path to use for the page title, rendering `'README.md'` if None
@@ -458,8 +462,8 @@ render_page(path=None, user_content=False, context=None, username=None, password
 - `api_url`: A different base URL for the github API, for example that of a Github Enterprise instance. The default is the public API https://api.github.com.
 - `title`: The page title, derived from `path` by default
 - `text`: A string or stream of Markdown text to render instead of being loaded from `path` (Note: `path` can be used to set the page title)
-- `theme`: The theme to use, `'light'` by default
 - `quiet`: Suppress logging to the terminal (except error messages), `False` by default
+- `theme`: The theme to use, `'light'` by default
 - `grip_class`: Use a custom [Grip class](#class-gripflask)
 
 

--- a/grip/api.py
+++ b/grip/api.py
@@ -13,7 +13,7 @@ from .renderers import GitHubRenderer, OfflineRenderer
 def create_app(path=None, user_content=False, context=None, username=None,
                password=None, render_offline=False, render_wide=False,
                render_inline=False, api_url=None, title=None, text=None,
-               autorefresh=None, quiet=None, grip_class=None):
+               autorefresh=None, quiet=None, theme=None, grip_class=None):
     """
     Creates a Grip application with the specified overrides.
     """
@@ -43,20 +43,20 @@ def create_app(path=None, user_content=False, context=None, username=None,
 
     # Create the customized app with default asset manager
     return grip_class(source, auth, renderer, None, render_wide,
-                      render_inline, title, autorefresh, quiet)
+                      render_inline, title, autorefresh, quiet, theme)
 
 
 def serve(path=None, host=None, port=None, user_content=False, context=None,
           username=None, password=None, render_offline=False,
           render_wide=False, render_inline=False, api_url=None, title=None,
-          autorefresh=True, browser=False, quiet=None, grip_class=None):
+          autorefresh=True, browser=False, quiet=None, theme=None, grip_class=None):
     """
     Starts a server to render the specified file or directory containing
     a README.
     """
     app = create_app(path, user_content, context, username, password,
                      render_offline, render_wide, render_inline, api_url,
-                     title, None, autorefresh, quiet, grip_class)
+                     title, None, autorefresh, quiet, theme, grip_class)
     app.run(host, port, open_browser=browser)
 
 
@@ -73,13 +73,13 @@ def render_page(path=None, user_content=False, context=None,
                 username=None, password=None,
                 render_offline=False, render_wide=False, render_inline=False,
                 api_url=None, title=None, text=None, quiet=None,
-                grip_class=None):
+                theme=None, grip_class=None):
     """
     Renders the specified markup text to an HTML page and returns it.
     """
     return create_app(path, user_content, context, username, password,
                       render_offline, render_wide, render_inline, api_url,
-                      title, text, False, quiet, grip_class).render()
+                      title, text, False, quiet, theme, grip_class).render()
 
 
 def render_content(text, user_content=False, context=None, username=None,
@@ -97,7 +97,7 @@ def render_content(text, user_content=False, context=None, username=None,
 def export(path=None, user_content=False, context=None,
            username=None, password=None, render_offline=False,
            render_wide=False, render_inline=True, out_filename=None,
-           api_url=None, title=None, quiet=False, grip_class=None):
+           api_url=None, title=None, quiet=False, theme=None, grip_class=None):
     """
     Exports the rendered HTML to a file.
     """
@@ -115,7 +115,7 @@ def export(path=None, user_content=False, context=None,
 
     page = render_page(path, user_content, context, username, password,
                        render_offline, render_wide, render_inline, api_url,
-                       title, None, quiet, grip_class)
+                       title, None, quiet, theme, grip_class)
 
     if export_to_stdout:
         try:

--- a/grip/app.py
+++ b/grip/app.py
@@ -119,7 +119,7 @@ class Grip(Flask):
 
         if theme not in ['light', 'dark', 'dark_dimmed']:
             log.error(
-                " * Invalid setting: THEME = '{0}'. Valid values are 'light', 'dark', 'dark_dimmed'."
+                " * Invalid theme: '{0}'. Valid values are 'light', 'dark', 'dark_dimmed'."
                 .format(theme)
             )
 

--- a/grip/command.py
+++ b/grip/command.py
@@ -37,7 +37,8 @@ Options:
                     The default is the filename.
   --norefresh       Do not automatically refresh the Readme content when
                     the file changes.
-  --quiet           Do not print to the terminal.
+  --theme=<theme>   The theme to use ('light', 'dark', 'dark_dimmed').
+  --quiet           Do not print to the terminal (except error messages).
 """
 
 from __future__ import print_function
@@ -107,7 +108,7 @@ def main(argv=None, force_utf8=True, patch_svg=True):
             export(args['<path>'], args['--user-content'], args['--context'],
                    args['--user'], password, False, args['--wide'],
                    not args['--no-inline'], args['<address>'],
-                   args['--api-url'], args['--title'], args['--quiet'])
+                   args['--api-url'], args['--title'], args['--quiet'], args['--theme'])
             return 0
         except ReadmeNotFoundError as ex:
             print('Error:', ex)
@@ -126,7 +127,7 @@ def main(argv=None, force_utf8=True, patch_svg=True):
         serve(path, host, port, args['--user-content'], args['--context'],
               args['--user'], password, False, args['--wide'], False,
               args['--api-url'], args['--title'], not args['--norefresh'],
-              args['--browser'], args['--quiet'], None)
+              args['--browser'], args['--quiet'], args['--theme'], None)
         return 0
     except ReadmeNotFoundError as ex:
         print('Error:', ex)

--- a/grip/settings.py
+++ b/grip/settings.py
@@ -29,3 +29,7 @@ API_URL = None
 
 # Custom styles
 STYLE_URLS = []
+
+
+# Valid values: 'light', 'dark', 'dark_dimmed'
+THEME = 'light'

--- a/grip/templates/base.html
+++ b/grip/templates/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-color-mode="auto" data-light-theme="{{ theme }}" data-dark-theme="{{ theme }}">
 <head>
   <meta charset="utf-8" />
   <title>{% block title %}Grip{% endblock %}</title>

--- a/grip/templates/index.html
+++ b/grip/templates/index.html
@@ -35,12 +35,12 @@
 {%- block scripts -%}
   <script>
     function showCanonicalImages() {
-      var images = document.getElementsByTagName('img');
+      const images = document.getElementsByTagName('img');
       if (!images) {
         return;
       }
-      for (var index = 0; index < images.length; index++) {
-        var image = images[index];
+      for (let index = 0; index < images.length; index++) {
+        const image = images[index];
         if (image.getAttribute('data-canonical-src') && image.src !== image.getAttribute('data-canonical-src')) {
           image.src = image.getAttribute('data-canonical-src');
         }
@@ -49,7 +49,7 @@
 
     function scrollToHash() {
       if (location.hash && !document.querySelector(':target')) {
-        var element = document.getElementById('user-content-' + location.hash.slice(1));
+        const element = document.getElementById('user-content-' + location.hash.slice(1));
         if (element) {
            element.scrollIntoView();
         }
@@ -57,13 +57,13 @@
     }
 
     function autorefreshContent(eventSourceUrl) {
-      var initialTitle = document.title;
-      var contentElement = document.getElementById('grip-content');
-      var source = new EventSource(eventSourceUrl);
-      var isRendering = false;
+      const initialTitle = document.title;
+      const contentElement = document.getElementById('grip-content');
+      const source = new EventSource(eventSourceUrl);
+      const isRendering = false;
 
       source.onmessage = function(ev) {
-        var msg = JSON.parse(ev.data);
+        const msg = JSON.parse(ev.data);
         if (msg.updating) {
           isRendering = true;
           document.title = '(Rendering) ' + document.title;
@@ -93,7 +93,7 @@
 
     showCanonicalImages();
 
-    var autorefreshUrl = document.getElementById('preview-page').getAttribute('data-autorefresh-url');
+    const autorefreshUrl = document.getElementById('preview-page').getAttribute('data-autorefresh-url');
     if (autorefreshUrl) {
       autorefreshContent(autorefreshUrl);
     }

--- a/grip/templates/index.html
+++ b/grip/templates/index.html
@@ -83,12 +83,33 @@
       }
     }
 
+    function onThemeChange(event) {
+      ['light', 'dark'].forEach((color) => {
+        document.documentElement.attributes[`data-${color}-theme`].value = event.target.value;
+      });
+    }
+
+    function initThemeSelect() {
+      const documentAttributes = document.documentElement.attributes;
+      let theme = documentAttributes['data-light-theme'].value;
+      const select = document.getElementById('theme');
+      select.onchange = onThemeChange;
+
+      for (let i = 0; i < select.options.length; i++) {
+        if (select.options[i].value == theme) {
+          select.selectedIndex = i;
+          break;
+        }
+      }
+    }
+
     window.onhashchange = function() {
       scrollToHash();
     }
 
     window.onload = function() {
       scrollToHash();
+      initThemeSelect();
     }
 
     showCanonicalImages();
@@ -115,6 +136,14 @@
                     <span class="octicon octicon-book"></span>
                     {{ title or filename }}
                   </h3>
+                  <div class="text-small">
+                    <label for="theme">Theme </label>
+                    <select id="theme" class="ml-1">
+                      <option value="light">Light</option>
+                      <option value="dark">Dark</option>
+                      <option value="dark_dimmed">Dark dimmed</option>
+                    </select>
+                  </div>
                 </div>
               {% endif %}
               <div class="Box-body">

--- a/grip/templates/index.html
+++ b/grip/templates/index.html
@@ -60,7 +60,7 @@
       const initialTitle = document.title;
       const contentElement = document.getElementById('grip-content');
       const source = new EventSource(eventSourceUrl);
-      const isRendering = false;
+      let isRendering = false;
 
       source.onmessage = function(ev) {
         const msg = JSON.parse(ev.data);

--- a/tests/output/app/gfm-test-user-content.html
+++ b/tests/output/app/gfm-test-user-content.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-color-mode="auto" data-light-theme="light" data-dark-theme="light">
 <head>
   <meta charset="utf-8" />
   <title>README.md - Grip</title>

--- a/tests/output/app/gfm-test-user-context.html
+++ b/tests/output/app/gfm-test-user-context.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-color-mode="auto" data-light-theme="light" data-dark-theme="light">
 <head>
   <meta charset="utf-8" />
   <title>gfm-test.md - Grip</title>

--- a/tests/output/app/gfm-test.html
+++ b/tests/output/app/gfm-test.html
@@ -626,7 +626,7 @@ Violets are Blue</p>
       const initialTitle = document.title;
       const contentElement = document.getElementById('grip-content');
       const source = new EventSource(eventSourceUrl);
-      const isRendering = false;
+      let isRendering = false;
 
       source.onmessage = function(ev) {
         const msg = JSON.parse(ev.data);

--- a/tests/output/app/gfm-test.html
+++ b/tests/output/app/gfm-test.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-color-mode="auto" data-light-theme="light" data-dark-theme="light">
 <head>
   <meta charset="utf-8" />
   <title>gfm-test.md - Grip</title>
@@ -38,6 +38,14 @@
                     <span class="octicon octicon-book"></span>
                     gfm-test.md
                   </h3>
+                  <div class="text-small">
+                    <label for="theme">Theme </label>
+                    <select id="theme" class="ml-1">
+                      <option value="light">Light</option>
+                      <option value="dark">Dark</option>
+                      <option value="dark_dimmed">Dark dimmed</option>
+                    </select>
+                  </div>
                 </div>
               
               <div class="Box-body">
@@ -593,12 +601,12 @@ Violets are Blue</p>
   </div>
   </div><script>
     function showCanonicalImages() {
-      var images = document.getElementsByTagName('img');
+      const images = document.getElementsByTagName('img');
       if (!images) {
         return;
       }
-      for (var index = 0; index < images.length; index++) {
-        var image = images[index];
+      for (let index = 0; index < images.length; index++) {
+        const image = images[index];
         if (image.getAttribute('data-canonical-src') && image.src !== image.getAttribute('data-canonical-src')) {
           image.src = image.getAttribute('data-canonical-src');
         }
@@ -607,7 +615,7 @@ Violets are Blue</p>
 
     function scrollToHash() {
       if (location.hash && !document.querySelector(':target')) {
-        var element = document.getElementById('user-content-' + location.hash.slice(1));
+        const element = document.getElementById('user-content-' + location.hash.slice(1));
         if (element) {
            element.scrollIntoView();
         }
@@ -615,13 +623,13 @@ Violets are Blue</p>
     }
 
     function autorefreshContent(eventSourceUrl) {
-      var initialTitle = document.title;
-      var contentElement = document.getElementById('grip-content');
-      var source = new EventSource(eventSourceUrl);
-      var isRendering = false;
+      const initialTitle = document.title;
+      const contentElement = document.getElementById('grip-content');
+      const source = new EventSource(eventSourceUrl);
+      const isRendering = false;
 
       source.onmessage = function(ev) {
-        var msg = JSON.parse(ev.data);
+        const msg = JSON.parse(ev.data);
         if (msg.updating) {
           isRendering = true;
           document.title = '(Rendering) ' + document.title;
@@ -641,17 +649,38 @@ Violets are Blue</p>
       }
     }
 
+    function onThemeChange(event) {
+      ['light', 'dark'].forEach((color) => {
+        document.documentElement.attributes[`data-${color}-theme`].value = event.target.value;
+      });
+    }
+
+    function initThemeSelect() {
+      const documentAttributes = document.documentElement.attributes;
+      let theme = documentAttributes['data-light-theme'].value;
+      const select = document.getElementById('theme');
+      select.onchange = onThemeChange;
+
+      for (let i = 0; i < select.options.length; i++) {
+        if (select.options[i].value == theme) {
+          select.selectedIndex = i;
+          break;
+        }
+      }
+    }
+
     window.onhashchange = function() {
       scrollToHash();
     }
 
     window.onload = function() {
       scrollToHash();
+      initThemeSelect();
     }
 
     showCanonicalImages();
 
-    var autorefreshUrl = document.getElementById('preview-page').getAttribute('data-autorefresh-url');
+    const autorefreshUrl = document.getElementById('preview-page').getAttribute('data-autorefresh-url');
     if (autorefreshUrl) {
       autorefreshContent(autorefreshUrl);
     }

--- a/tests/output/app/simple-user-content.html
+++ b/tests/output/app/simple-user-content.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-color-mode="auto" data-light-theme="light" data-dark-theme="light">
 <head>
   <meta charset="utf-8" />
   <title>README.md - Grip</title>

--- a/tests/output/app/simple-user-context.html
+++ b/tests/output/app/simple-user-context.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-color-mode="auto" data-light-theme="light" data-dark-theme="light">
 <head>
   <meta charset="utf-8" />
   <title>simple.md - Grip</title>

--- a/tests/output/app/simple.html
+++ b/tests/output/app/simple.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-color-mode="auto" data-light-theme="light" data-dark-theme="light">
 <head>
   <meta charset="utf-8" />
   <title>simple.md - Grip</title>
@@ -38,6 +38,14 @@
                     <span class="octicon octicon-book"></span>
                     simple.md
                   </h3>
+                  <div class="text-small">
+                    <label for="theme">Theme </label>
+                    <select id="theme" class="ml-1">
+                      <option value="light">Light</option>
+                      <option value="dark">Dark</option>
+                      <option value="dark_dimmed">Dark dimmed</option>
+                    </select>
+                  </div>
                 </div>
               
               <div class="Box-body">
@@ -58,12 +66,12 @@
   </div>
   </div><script>
     function showCanonicalImages() {
-      var images = document.getElementsByTagName('img');
+      const images = document.getElementsByTagName('img');
       if (!images) {
         return;
       }
-      for (var index = 0; index < images.length; index++) {
-        var image = images[index];
+      for (let index = 0; index < images.length; index++) {
+        const image = images[index];
         if (image.getAttribute('data-canonical-src') && image.src !== image.getAttribute('data-canonical-src')) {
           image.src = image.getAttribute('data-canonical-src');
         }
@@ -72,7 +80,7 @@
 
     function scrollToHash() {
       if (location.hash && !document.querySelector(':target')) {
-        var element = document.getElementById('user-content-' + location.hash.slice(1));
+        const element = document.getElementById('user-content-' + location.hash.slice(1));
         if (element) {
            element.scrollIntoView();
         }
@@ -80,13 +88,13 @@
     }
 
     function autorefreshContent(eventSourceUrl) {
-      var initialTitle = document.title;
-      var contentElement = document.getElementById('grip-content');
-      var source = new EventSource(eventSourceUrl);
-      var isRendering = false;
+      const initialTitle = document.title;
+      const contentElement = document.getElementById('grip-content');
+      const source = new EventSource(eventSourceUrl);
+      const isRendering = false;
 
       source.onmessage = function(ev) {
-        var msg = JSON.parse(ev.data);
+        const msg = JSON.parse(ev.data);
         if (msg.updating) {
           isRendering = true;
           document.title = '(Rendering) ' + document.title;
@@ -106,17 +114,38 @@
       }
     }
 
+    function onThemeChange(event) {
+      ['light', 'dark'].forEach((color) => {
+        document.documentElement.attributes[`data-${color}-theme`].value = event.target.value;
+      });
+    }
+
+    function initThemeSelect() {
+      const documentAttributes = document.documentElement.attributes;
+      let theme = documentAttributes['data-light-theme'].value;
+      const select = document.getElementById('theme');
+      select.onchange = onThemeChange;
+
+      for (let i = 0; i < select.options.length; i++) {
+        if (select.options[i].value == theme) {
+          select.selectedIndex = i;
+          break;
+        }
+      }
+    }
+
     window.onhashchange = function() {
       scrollToHash();
     }
 
     window.onload = function() {
       scrollToHash();
+      initThemeSelect();
     }
 
     showCanonicalImages();
 
-    var autorefreshUrl = document.getElementById('preview-page').getAttribute('data-autorefresh-url');
+    const autorefreshUrl = document.getElementById('preview-page').getAttribute('data-autorefresh-url');
     if (autorefreshUrl) {
       autorefreshContent(autorefreshUrl);
     }

--- a/tests/output/app/simple.html
+++ b/tests/output/app/simple.html
@@ -91,7 +91,7 @@
       const initialTitle = document.title;
       const contentElement = document.getElementById('grip-content');
       const source = new EventSource(eventSourceUrl);
-      const isRendering = false;
+      let isRendering = false;
 
       source.onmessage = function(ev) {
         const msg = JSON.parse(ev.data);

--- a/tests/output/app/zero-user-content.html
+++ b/tests/output/app/zero-user-content.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-color-mode="auto" data-light-theme="light" data-dark-theme="light">
 <head>
   <meta charset="utf-8" />
   <title>zero.md - Grip</title>

--- a/tests/output/app/zero-user-context.html
+++ b/tests/output/app/zero-user-context.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-color-mode="auto" data-light-theme="light" data-dark-theme="light">
 <head>
   <meta charset="utf-8" />
   <title>zero.md - Grip</title>

--- a/tests/output/app/zero.html
+++ b/tests/output/app/zero.html
@@ -88,7 +88,7 @@
       const initialTitle = document.title;
       const contentElement = document.getElementById('grip-content');
       const source = new EventSource(eventSourceUrl);
-      const isRendering = false;
+      let isRendering = false;
 
       source.onmessage = function(ev) {
         const msg = JSON.parse(ev.data);

--- a/tests/output/app/zero.html
+++ b/tests/output/app/zero.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-color-mode="auto" data-light-theme="light" data-dark-theme="light">
 <head>
   <meta charset="utf-8" />
   <title>zero.md - Grip</title>
@@ -38,6 +38,14 @@
                     <span class="octicon octicon-book"></span>
                     zero.md
                   </h3>
+                  <div class="text-small">
+                    <label for="theme">Theme </label>
+                    <select id="theme" class="ml-1">
+                      <option value="light">Light</option>
+                      <option value="dark">Dark</option>
+                      <option value="dark_dimmed">Dark dimmed</option>
+                    </select>
+                  </div>
                 </div>
               
               <div class="Box-body">
@@ -55,12 +63,12 @@
   </div>
   </div><script>
     function showCanonicalImages() {
-      var images = document.getElementsByTagName('img');
+      const images = document.getElementsByTagName('img');
       if (!images) {
         return;
       }
-      for (var index = 0; index < images.length; index++) {
-        var image = images[index];
+      for (let index = 0; index < images.length; index++) {
+        const image = images[index];
         if (image.getAttribute('data-canonical-src') && image.src !== image.getAttribute('data-canonical-src')) {
           image.src = image.getAttribute('data-canonical-src');
         }
@@ -69,7 +77,7 @@
 
     function scrollToHash() {
       if (location.hash && !document.querySelector(':target')) {
-        var element = document.getElementById('user-content-' + location.hash.slice(1));
+        const element = document.getElementById('user-content-' + location.hash.slice(1));
         if (element) {
            element.scrollIntoView();
         }
@@ -77,13 +85,13 @@
     }
 
     function autorefreshContent(eventSourceUrl) {
-      var initialTitle = document.title;
-      var contentElement = document.getElementById('grip-content');
-      var source = new EventSource(eventSourceUrl);
-      var isRendering = false;
+      const initialTitle = document.title;
+      const contentElement = document.getElementById('grip-content');
+      const source = new EventSource(eventSourceUrl);
+      const isRendering = false;
 
       source.onmessage = function(ev) {
-        var msg = JSON.parse(ev.data);
+        const msg = JSON.parse(ev.data);
         if (msg.updating) {
           isRendering = true;
           document.title = '(Rendering) ' + document.title;
@@ -103,17 +111,38 @@
       }
     }
 
+    function onThemeChange(event) {
+      ['light', 'dark'].forEach((color) => {
+        document.documentElement.attributes[`data-${color}-theme`].value = event.target.value;
+      });
+    }
+
+    function initThemeSelect() {
+      const documentAttributes = document.documentElement.attributes;
+      let theme = documentAttributes['data-light-theme'].value;
+      const select = document.getElementById('theme');
+      select.onchange = onThemeChange;
+
+      for (let i = 0; i < select.options.length; i++) {
+        if (select.options[i].value == theme) {
+          select.selectedIndex = i;
+          break;
+        }
+      }
+    }
+
     window.onhashchange = function() {
       scrollToHash();
     }
 
     window.onload = function() {
       scrollToHash();
+      initThemeSelect();
     }
 
     showCanonicalImages();
 
-    var autorefreshUrl = document.getElementById('preview-page').getAttribute('data-autorefresh-url');
+    const autorefreshUrl = document.getElementById('preview-page').getAttribute('data-autorefresh-url');
     if (autorefreshUrl) {
       autorefreshContent(autorefreshUrl);
     }


### PR DESCRIPTION
Thank you so much for this fantastic tool!

This PR adds support for setting the default theme. The standard GitHub `Light`, `Dark`, and `Dark dimmed` themes are supported. The theme can be set in the config file via a `THEME` variable, via `--theme=<theme>` on the command line, or dynamically via a menu in generated non-user content pages.

The template JavaScript has also been modernized to use `const` and `let` instead of `var`. GitHub does not support any browsers that do not support this, there's no reason for Grip to.

API and CLI tests have been updated. Note the GitHub tests were failing before this PR, I didn't bother fixing them.