### PR TITLE
Require Werkzeug and import safe_utils from there, not Flask

### DIFF
--- a/grip/assets.py
+++ b/grip/assets.py
@@ -13,7 +13,7 @@ except ImportError:
     from urllib.parse import urljoin
 
 import requests
-from flask import safe_join
+from werkzeug.utils import safe_join
 
 from .constants import (
     STYLE_URLS_SOURCE, STYLE_URLS_RES, STYLE_ASSET_URLS_RE,

--- a/grip/readers.py
+++ b/grip/readers.py
@@ -8,7 +8,7 @@ import posixpath
 import sys
 from abc import ABCMeta, abstractmethod
 
-from flask import safe_join
+from werkzeug.utils import safe_join
 
 from .constants import DEFAULT_FILENAMES, DEFAULT_FILENAME
 from .exceptions import ReadmeNotFoundError

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ Markdown>=2.5.1
 path-and-address>=2.0.1
 Pygments>=1.6
 requests>=2.4.1
+Werkzeug>=2.1.0


### PR DESCRIPTION
Flask removed the already deprecated function `safe_utils` in `2.1.0`.