### PR TITLE
Add Math support

### DIFF
--- a/grip/api.py
+++ b/grip/api.py
@@ -13,7 +13,7 @@ from .renderers import GitHubRenderer, OfflineRenderer
 def create_app(path=None, user_content=False, context=None, username=None,
                password=None, render_offline=False, render_wide=False,
                render_inline=False, api_url=None, title=None, text=None,
-               autorefresh=None, quiet=None, grip_class=None):
+               autorefresh=None, render_math=False, quiet=None, grip_class=None):
     """
     Creates a Grip application with the specified overrides.
     """
@@ -43,20 +43,20 @@ def create_app(path=None, user_content=False, context=None, username=None,
 
     # Create the customized app with default asset manager
     return grip_class(source, auth, renderer, None, render_wide,
-                      render_inline, title, autorefresh, quiet)
+                      render_inline, title, autorefresh, render_math, quiet)
 
 
 def serve(path=None, host=None, port=None, user_content=False, context=None,
           username=None, password=None, render_offline=False,
           render_wide=False, render_inline=False, api_url=None, title=None,
-          autorefresh=True, browser=False, quiet=None, grip_class=None):
+          autorefresh=True, browser=False, render_math=False, quiet=None, grip_class=None):
     """
     Starts a server to render the specified file or directory containing
     a README.
     """
     app = create_app(path, user_content, context, username, password,
                      render_offline, render_wide, render_inline, api_url,
-                     title, None, autorefresh, quiet, grip_class)
+                     title, None, autorefresh, render_math, quiet, grip_class)
     app.run(host, port, open_browser=browser)
 
 
@@ -72,14 +72,14 @@ def clear_cache(grip_class=None):
 def render_page(path=None, user_content=False, context=None,
                 username=None, password=None,
                 render_offline=False, render_wide=False, render_inline=False,
-                api_url=None, title=None, text=None, quiet=None,
+                api_url=None, title=None, text=None, render_math=False, quiet=None,
                 grip_class=None):
     """
     Renders the specified markup text to an HTML page and returns it.
     """
     return create_app(path, user_content, context, username, password,
                       render_offline, render_wide, render_inline, api_url,
-                      title, text, False, quiet, grip_class).render()
+                      title, text, False, render_math, quiet, grip_class).render()
 
 
 def render_content(text, user_content=False, context=None, username=None,
@@ -97,7 +97,7 @@ def render_content(text, user_content=False, context=None, username=None,
 def export(path=None, user_content=False, context=None,
            username=None, password=None, render_offline=False,
            render_wide=False, render_inline=True, out_filename=None,
-           api_url=None, title=None, quiet=False, grip_class=None):
+           api_url=None, title=None, render_math=False, quiet=False, grip_class=None):
     """
     Exports the rendered HTML to a file.
     """
@@ -115,7 +115,7 @@ def export(path=None, user_content=False, context=None,
 
     page = render_page(path, user_content, context, username, password,
                        render_offline, render_wide, render_inline, api_url,
-                       title, None, quiet, grip_class)
+                       title, None, render_math, quiet, grip_class)
 
     if export_to_stdout:
         try:

--- a/grip/app.py
+++ b/grip/app.py
@@ -30,7 +30,8 @@ from . import __version__
 from .assets import GitHubAssetManager, ReadmeAssetManager
 from .browser import start_browser_when_ready
 from .constants import (
-    DEFAULT_GRIPHOME, DEFAULT_GRIPURL, STYLE_ASSET_URLS_INLINE_FORMAT)
+    DEFAULT_GRIPHOME, DEFAULT_GRIPURL, STYLE_ASSET_URLS_INLINE_FORMAT,
+    DEFAULT_MATH_JAX_CDN_URL)
 from .exceptions import AlreadyRunningError, ReadmeNotFoundError
 from .readers import DirectoryReader
 from .renderers import GitHubRenderer, ReadmeRenderer
@@ -43,7 +44,7 @@ class Grip(Flask):
     """
     def __init__(self, source=None, auth=None, renderer=None,
                  assets=None, render_wide=None, render_inline=None, title=None,
-                 autorefresh=None, quiet=None, grip_url=None,
+                 autorefresh=None, render_math=None, quiet=None, grip_url=None,
                  static_url_path=None, instance_path=None, **kwargs):
         # Defaults
         if source is None or isinstance(source, str_type):
@@ -52,6 +53,8 @@ class Grip(Flask):
             render_wide = False
         if render_inline is None:
             render_inline = False
+        if render_math is None:
+            render_math = False
 
         # Defaults from ENV
         if grip_url is None:
@@ -104,6 +107,7 @@ class Grip(Flask):
         self.renderer = renderer
         self.assets = assets
         self.render_wide = render_wide
+        self.render_math = render_math
         self.render_inline = render_inline
         self.title = title
         self.quiet = quiet
@@ -217,7 +221,8 @@ class Grip(Flask):
             title=self.title, content=content, favicon=favicon,
             user_content=self.renderer.user_content,
             wide_style=self.render_wide, style_urls=self.assets.style_urls,
-            styles=self.assets.styles, autorefresh_url=autorefresh_url)
+            styles=self.assets.styles, autorefresh_url=autorefresh_url,
+            render_math=self.render_math, math_jax_cdn_url=DEFAULT_MATH_JAX_CDN_URL)
 
     def _render_refresh(self, subpath=None):
         if not self.autorefresh:

--- a/grip/command.py
+++ b/grip/command.py
@@ -24,6 +24,7 @@ Options:
   --pass=<password> A GitHub password or auth token for API auth.
   --wide            Renders wide, i.e. when the side nav is collapsed.
                     This only takes effect when --user-content is used.
+  --render-math     Renders LaTex equations with MathJax.
   --clear           Clears the cached styles and assets and exits.
   --export          Exports to <path>.html or README.md instead of
                     serving, optionally using [<address>] as the out
@@ -107,7 +108,8 @@ def main(argv=None, force_utf8=True, patch_svg=True):
             export(args['<path>'], args['--user-content'], args['--context'],
                    args['--user'], password, False, args['--wide'],
                    not args['--no-inline'], args['<address>'],
-                   args['--api-url'], args['--title'], args['--quiet'])
+                   args['--api-url'], args['--title'], args['--render-math'],
+                   args['--quiet'])
             return 0
         except ReadmeNotFoundError as ex:
             print('Error:', ex)
@@ -126,7 +128,7 @@ def main(argv=None, force_utf8=True, patch_svg=True):
         serve(path, host, port, args['--user-content'], args['--context'],
               args['--user'], password, False, args['--wide'], False,
               args['--api-url'], args['--title'], not args['--norefresh'],
-              args['--browser'], args['--quiet'], None)
+              args['--browser'], args['--render-math'], args['--quiet'], None)
         return 0
     except ReadmeNotFoundError as ex:
         print('Error:', ex)

--- a/grip/constants.py
+++ b/grip/constants.py
@@ -22,6 +22,8 @@ DEFAULT_GRIPURL = '/__/grip'
 # The public GitHub API
 DEFAULT_API_URL = 'https://api.github.com'
 
+DEFAULT_MATH_JAX_CDN_URL = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.2.2/es5/tex-chtml.min.js'
+
 
 # Style parsing
 STYLE_URLS_SOURCE = 'https://github.com/joeyespo/grip'

--- a/grip/templates/index.html
+++ b/grip/templates/index.html
@@ -33,6 +33,19 @@
 {%- endblock -%}
 
 {%- block scripts -%}
+{%- if render_math %}
+<script>
+    MathJax = {
+      tex: {
+        inlineMath: [['$', '$']],
+        displayMath: [['$$', '$$']]
+      }
+    };
+</script>
+<script type="text/javascript" id="MathJax-script"
+  src="{{ math_jax_cdn_url }}">
+</script>
+{%- endif %}
   <script>
     function showCanonicalImages() {
       var images = document.getElementsByTagName('img');
@@ -56,6 +69,26 @@
       }
     }
 
+{%- if render_math %}
+    function typesetMath() {
+      var preElements = document.getElementsByTagName('pre');
+      for (let p of preElements) {
+        if (p.lang==="math") {
+          p.style.backgroundColor = "white";
+          p.classList.add("mathjax_process");
+          let codeElements = p.getElementsByTagName('code');
+          if (codeElements.length===1) {
+            let c = codeElements[0];
+            c.classList.add("mathjax_process");
+            c.innerHTML.replace("$$", "\$$");
+            c.innerHTML = "$$"+c.innerHTML+"$$";
+          }
+        }
+      }
+      MathJax.typeset();
+    }
+{%- endif %}
+
     function autorefreshContent(eventSourceUrl) {
       var initialTitle = document.title;
       var contentElement = document.getElementById('grip-content');
@@ -72,6 +105,9 @@
           document.title = initialTitle;
           contentElement.innerHTML = msg.content;
           showCanonicalImages();
+{%- if render_math %}
+          typesetMath();
+{%- endif %}
         }
       }
 
@@ -88,6 +124,9 @@
     }
 
     window.onload = function() {
+{%- if render_math %}
+      typesetMath();
+{%- endif %}
       scrollToHash();
     }
 


### PR DESCRIPTION
Add support for rendering mathematical expressions as requested in #362 with MathJax.

In the screenshot below the examples from https://github.blog/2022-05-19-math-support-in-markdown/ and https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/writing-mathematical-expressions were tested:
![screenshot](https://user-images.githubusercontent.com/54741970/200147347-6668de36-4cb9-45c8-a7a4-b359cb35a90a.jpg)

The MathJax script is loaded from a CDN from the url defined in the `grip/constants.py` file. If you want, I can also add a command line option for changing the url.