### PR TITLE
Fix scrollToHash failing on links

### DIFF
--- a/grip/templates/base.html
+++ b/grip/templates/base.html
@@ -10,6 +10,16 @@
   <div class="page">
     {% block page %}{% endblock %}
   </div>
-  {%- block scripts %}{% endblock %}
+  {%- block scripts %}{% endblock -%}
+  <script>
+    function scrollToHash() {
+      if (location.hash && !document.querySelector(":target")) {
+        var elements = document.getElementsByName('user-content-' + location.hash.slice(1));
+        if (elements.length > 0) {
+          elements[elements.length - 1].scrollIntoView();
+        }
+      }
+    }
+  </script>
 </body>
 </html>

--- a/grip/templates/index.html
+++ b/grip/templates/index.html
@@ -47,15 +47,6 @@
       }
     }
 
-    function scrollToHash() {
-      if (location.hash && !document.querySelector(':target')) {
-        var element = document.getElementById('user-content-' + location.hash.slice(1));
-        if (element) {
-           element.scrollIntoView();
-        }
-      }
-    }
-
     function autorefreshContent(eventSourceUrl) {
       var initialTitle = document.title;
       var contentElement = document.getElementById('grip-content');

--- a/grip/templates/limit.html
+++ b/grip/templates/limit.html
@@ -43,14 +43,6 @@
 
 {%- block scripts -%}
   <script>
-    function scrollToHash() {
-      if (location.hash && !document.querySelector(":target")) {
-        var elements = document.getElementsByName('user-content-' + location.hash.slice(1));
-        if (elements.length > 0) {
-          elements[elements.length - 1].scrollIntoView();
-        }
-      }
-    }
     window.onhashchange = function() {
       scrollToHash();
     }


### PR DESCRIPTION
Fix #368 

This change fixes the issue with `<a ...>` anchor tags not scrolling to their corresponding hash when clicked.

* Minimal working example for verifying this bugfix is also provided by the issue: #368 

**Description of changes:**

The version of the function `scrollToHash` in templates/index.html is using `getElementById`, which fails for anchor tags such as `<a name="foo">`; whereas the homonymously named function in templates/limit.html (using `getElementsByName` instead) does work correctly.

This commit merges these two functions with the same name but differing function body into the correctly working version from templates/limit.html, and moves it to templates/base.html, such that it can be shared and extended by the Flask templates accordingly.

Note that as this change modified the templates, the tests must be regenerated by running the tests/regenerate.py script in order for them to pass.