### PR TITLE
Add mermaid diagrams support through javascript

### DIFF
--- a/grip/templates/index.html
+++ b/grip/templates/index.html
@@ -57,33 +57,6 @@
       }
     }
 
-    function autorefreshContent(eventSourceUrl) {
-      var initialTitle = document.title;
-      var contentElement = document.getElementById('grip-content');
-      var source = new EventSource(eventSourceUrl);
-      var isRendering = false;
-
-      source.onmessage = function(ev) {
-        var msg = JSON.parse(ev.data);
-        if (msg.updating) {
-          isRendering = true;
-          document.title = '(Rendering) ' + document.title;
-        } else {
-          isRendering = false;
-          document.title = initialTitle;
-          contentElement.innerHTML = msg.content;
-          showCanonicalImages();
-        }
-      }
-
-      source.onerror = function(e) {
-        if (e.readyState === EventSource.CLOSED && isRendering) {
-          isRendering = false;
-          document.title = initialTitle;
-        }
-      }
-    }
-
     function enableMermaidSupport() {
       const elements = document.querySelectorAll('.highlight-source-mermaid pre')
       if (elements.length === 0) {
@@ -100,6 +73,34 @@
       });
     }
 
+    function autorefreshContent(eventSourceUrl) {
+      var initialTitle = document.title;
+      var contentElement = document.getElementById('grip-content');
+      var source = new EventSource(eventSourceUrl);
+      var isRendering = false;
+
+      source.onmessage = function(ev) {
+        var msg = JSON.parse(ev.data);
+        if (msg.updating) {
+          isRendering = true;
+          document.title = '(Rendering) ' + document.title;
+        } else {
+          isRendering = false;
+          document.title = initialTitle;
+          contentElement.innerHTML = msg.content;
+          showCanonicalImages();
+          enableMermaidSupport();
+        }
+      }
+
+      source.onerror = function(e) {
+        if (e.readyState === EventSource.CLOSED && isRendering) {
+          isRendering = false;
+          document.title = initialTitle;
+        }
+      }
+    }
+
     window.onhashchange = function() {
       scrollToHash();
     }
@@ -107,10 +108,10 @@
     window.onload = function() {
       scrollToHash();
 
-      enableMermaidSupport();
     }
 
     showCanonicalImages();
+    enableMermaidSupport();
 
     var autorefreshUrl = document.getElementById('preview-page').getAttribute('data-autorefresh-url');
     if (autorefreshUrl) {

--- a/grip/templates/index.html
+++ b/grip/templates/index.html
@@ -33,7 +33,8 @@
 {%- endblock -%}
 
 {%- block scripts -%}
-  <script>
+  <script type="module">
+    import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.esm.min.mjs';
     function showCanonicalImages() {
       var images = document.getElementsByTagName('img');
       if (!images) {
@@ -83,12 +84,30 @@
       }
     }
 
+    function enableMermaidSupport() {
+      const elements = document.querySelectorAll('.highlight-source-mermaid pre')
+      if (elements.length === 0) {
+        return;
+      }
+      // There is no way to tell the github API to not highlight mermaid. So we need
+      // to reverse what they've done in terms of highlighting.
+      elements.forEach(function(pre) {
+        pre.innerHTML = pre.innerText;
+      });
+
+      mermaid.run({
+        querySelector: '.highlight-source-mermaid pre',
+      });
+    }
+
     window.onhashchange = function() {
       scrollToHash();
     }
 
     window.onload = function() {
       scrollToHash();
+
+      enableMermaidSupport();
     }
 
     showCanonicalImages();


### PR DESCRIPTION
This is the best option that I could find for this. Another way would be to shellout to the `mermaid-cli` but that seems too heavyweight and needs yet another cli to be installed on the machine. Where the pure javascript library is just portable.

What this does is that it reverses the highlighting done github API and then it runs the mermaid javascript library on top of the pre tags that are created.

The only downside that I can see is that there is now a dependency on the mermaid javascript library in the template. There might be ways to get around this by loading the file dynamically but that seems far too complex for my taste.

This should hopefully fix https://github.com/joeyespo/grip/issues/355