### PR TITLE
Bugfix: Titles with accents (example: Spanish) was not working

### DIFF
--- a/grip/templates/index.html
+++ b/grip/templates/index.html
@@ -49,7 +49,8 @@
 
     function scrollToHash() {
       if (location.hash && !document.querySelector(':target')) {
-        var element = document.getElementById('user-content-' + location.hash.slice(1));
+        var elementId = 'user-content-' + decodeURIComponent(location.hash.slice(1));
+        var element = document.getElementById(elementId);
         if (element) {
            element.scrollIntoView();
         }


### PR DESCRIPTION
Markdown titles that contains accents (example: in Spanish) has an encoded `location.hash`.

To make the scrollDown working in that cases, you need to use `decodeURIComponent`, in the other case the element will not be found and scrollDown will not occur.

An example with the title "Configuración" ("Configuration" in Spanish)

### Configuración

```
location.hash:
"#2-configuraci%C3%B3n"
# the letter "ó" is encoded
```

But the element ID has the accent without the encoding:

![Captura de pantalla 2024-09-12 a la(s) 10 12 03](https://github.com/user-attachments/assets/77f49a56-926d-4b5d-ba81-84635d81182e)
