### PR TITLE
Added support for theme from settings.py rather than just from the cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ To customize Grip, create `~/.grip/settings.py`, then add one or more of the fol
 - `AUTOREFRESH`: Whether to automatically refresh the Readme content when the file changes, `True` by default
 - `QUIET`: Do not print extended information, `False` by default
 - `STYLE_URLS`: Additional URLs that will be added to the rendered page, `[]` by default
+- `THEME`: The theme to use when not provided as a CLI argument, `light` by default
 - `USERNAME`: The username to use when not provided as a CLI argument, `None` by default
 - `PASSWORD`: The password or [personal access token][] to use when not provided as a CLI argument (*Please don't save your passwords here.* Instead, use an access token or drop in this code [grab your password from a password manager][keychain-access]), `None` by default
 

--- a/grip/app.py
+++ b/grip/app.py
@@ -114,7 +114,7 @@ class Grip(Flask):
         self.theme = theme
         localtheme = self.config['THEME']
         if localtheme:
-            self.theme = (localtheme or 'light')
+            self.theme = localtheme
 
         # Overridable attributes
         if self.renderer is None:

--- a/grip/app.py
+++ b/grip/app.py
@@ -112,6 +112,9 @@ class Grip(Flask):
             log = logging.getLogger('werkzeug')
             log.setLevel(logging.ERROR)
         self.theme = theme
+        localtheme = self.config['THEME']
+        if localtheme:
+            self.theme = (localtheme or 'light')
 
         # Overridable attributes
         if self.renderer is None:

--- a/grip/settings.py
+++ b/grip/settings.py
@@ -29,3 +29,6 @@ API_URL = None
 
 # Custom styles
 STYLE_URLS = []
+
+# Custome theme
+THEME = 'light'


### PR DESCRIPTION
I want to run the grip local renderer, but have it display using the github-dark theme.  This seems to have been added as a CLI option, but its was not available on the local server renderer.  These changes add it.  