### PR TITLE
Update failing tests due to changes in Github HTML

### DIFF
--- a/tests/output/app/gfm-test-user-context.html
+++ b/tests/output/app/gfm-test-user-context.html
@@ -52,7 +52,7 @@ testing a renderer with.</p>
 and <a href="https://help.github.com/articles/github-flavored-markdown/">GitHub Flavored Markdown</a>,<br>
 followed by a list of one-offs.</p>
 <h2 dir="auto">Inline HTML</h2>
-<table role="table">
+<markdown-accessiblity-table><table role="table">
   <tbody><tr>
     <td>Foo</td>
   </tr>
@@ -62,7 +62,7 @@ followed by a list of one-offs.</p>
       E.g., you can’t use Markdown-style *emphasis* inside an HTML block.
     </td>
   </tr>
-</tbody></table>
+</tbody></table></markdown-accessiblity-table>
 <p dir="auto">Span-level HTML tags — e.g. &lt;span&gt;, &lt;cite&gt;, or &lt;del&gt; — can be used anywhere<br>
 in a Markdown paragraph, list item, or header. If you want, you can even use HTML tags instead<br>
 of Markdown formatting; e.g. if you’d prefer to use HTML &lt;a&gt; or &lt;img&gt; tags instead<br>
@@ -82,7 +82,7 @@ of Markdown’s link or image syntax, go right ahead.</p>
 <li>4 &lt; 5 should render the same as 4 &lt; 5</li>
 </ul>
 <p dir="auto">Note that GitHub Flavored Markdown has URL autolinking, which will <em>not</em><br>
-convert <code>&amp;amp;</code>. So these two should yield different links:</p>
+convert <code class="notranslate">&amp;amp;</code>. So these two should yield different links:</p>
 <ul dir="auto">
 <li><a href="http://images.google.com/images?num=30&amp;q=larry+bird" rel="nofollow">http://images.google.com/images?num=30&amp;q=larry+bird</a></li>
 <li><a href="http://images.google.com/images?num=30&amp;amp;q=larry+bird" rel="nofollow">http://images.google.com/images?num=30&amp;amp;q=larry+bird</a></li>
@@ -91,11 +91,11 @@ convert <code>&amp;amp;</code>. So these two should yield different links:</p>
 <p dir="auto">This is a normal paragraph.</p>
 <p dir="auto">This and the next sentence is separated by a single newline.<br>
 This should be on the same line.</p>
-<p dir="auto">This and the next sentence is joined by a single <code>&lt;br /&gt;</code>. <br><br>
+<p dir="auto">This and the next sentence is joined by a single <code class="notranslate">&lt;br /&gt;</code>. <br><br>
 This should be on a new line, directly below.</p>
-<p dir="auto">These two sentences are separated by two <code>&lt;br /&gt;</code> tags. <br><br><br>
+<p dir="auto">These two sentences are separated by two <code class="notranslate">&lt;br /&gt;</code> tags. <br><br><br>
 This should be two lines below.</p>
-<p dir="auto">These two paragraphs are separated by two <code>&lt;br /&gt;</code> tags. <br><br></p>
+<p dir="auto">These two paragraphs are separated by two <code class="notranslate">&lt;br /&gt;</code> tags. <br><br></p>
 <p dir="auto">This should be three lines below.</p>
 <h2 dir="auto">Headers</h2>
 <p dir="auto">Here are some headers followed by <a href="https://en.wikipedia.org/wiki/Lorem_ipsum" rel="nofollow">Lorem Ipsum</a>.</p>
@@ -151,7 +151,7 @@ id sem consectetuer libero luctus adipiscing.</p>
 <li>This is the second list item.</li>
 </ol>
 <p dir="auto">Here's some example code:</p>
-<pre><code>return shell_exec("echo $input | $markdown_script");
+<pre class="notranslate"><code class="notranslate">return shell_exec("echo $input | $markdown_script");
 </code></pre>
 </blockquote>
 <h2 dir="auto">Lists</h2>
@@ -265,7 +265,7 @@ inside a list item.</p>
 <ul dir="auto">
 <li>
 <p dir="auto">A list item with a code block:</p>
-<pre><code>&lt;code goes here&gt;
+<pre class="notranslate"><code class="notranslate">&lt;code goes here&gt;
 </code></pre>
 </li>
 </ul>
@@ -276,15 +276,15 @@ inside a list item.</p>
 <p dir="auto">1986. What a great season. (<em>whew!</em> there we go)</p>
 <h2 dir="auto">Code blocks</h2>
 <p dir="auto">This is a normal paragraph:</p>
-<pre><code>This is a code block.
+<pre class="notranslate"><code class="notranslate">This is a code block.
 </code></pre>
 <p dir="auto">Here is an example of AppleScript:</p>
-<pre><code>tell application "Foo"
+<pre class="notranslate"><code class="notranslate">tell application "Foo"
     beep
 end tell
 </code></pre>
 <p dir="auto">Markdown will handle the hassle of encoding the ampersands and angle brackets:</p>
-<pre><code>&lt;div class="footer"&gt;
+<pre class="notranslate"><code class="notranslate">&lt;div class="footer"&gt;
     &amp;copy; 2004 Foo Corporation
 &lt;/div&gt;
 
@@ -293,10 +293,10 @@ def this_is
   puts "some #{4-space-indent} code"
 end
 </code></pre>
-<code>
+<code class="notranslate">
 print('Code block')
 </code>
-<pre>print('Pre block')
+<pre class="notranslate">print('Pre block')
 </pre>
 <h2 dir="auto">Horizontal rules</h2>
 <hr>
@@ -330,19 +330,19 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 </ul>
 <h2 dir="auto">Code</h2>
 <ul dir="auto">
-<li>Use the <code>printf()</code> function.</li>
-<li><code>There is a literal backtick (`) here.</code></li>
-<li>A single backtick in a code span: <code>`</code></li>
-<li>A backtick-delimited string in a code span: <code>`foo`</code></li>
-<li>Please don't use any <code>&lt;blink&gt;</code> tags.</li>
-<li><code>&amp;#8212;</code> is the decimal-encoded equivalent of <code>&amp;mdash;</code></li>
+<li>Use the <code class="notranslate">printf()</code> function.</li>
+<li><code class="notranslate">There is a literal backtick (`) here.</code></li>
+<li>A single backtick in a code span: <code class="notranslate">`</code></li>
+<li>A backtick-delimited string in a code span: <code class="notranslate">`foo`</code></li>
+<li>Please don't use any <code class="notranslate">&lt;blink&gt;</code> tags.</li>
+<li><code class="notranslate">&amp;#8212;</code> is the decimal-encoded equivalent of <code class="notranslate">&amp;mdash;</code></li>
 </ul>
 <h2 dir="auto">Images</h2>
 <ul dir="auto">
-<li><a target="_blank" rel="noopener noreferrer" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" style="max-width: 100%;"></a></li>
-<li><a target="_blank" rel="noopener noreferrer" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" title="Optional title" style="max-width: 100%;"></a></li>
-<li><a target="_blank" rel="noopener noreferrer" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" title="Optional title attribute" style="max-width: 100%;"></a></li>
-<li><a target="_blank" rel="noopener noreferrer" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" width="32" height="32" style="max-width: 100%;"></a>   ← bigger &amp; blurrier</li>
+<li><a target="_blank" rel="noopener noreferrer nofollow" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" style="max-width: 100%;"></a></li>
+<li><a target="_blank" rel="noopener noreferrer nofollow" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" title="Optional title" style="max-width: 100%;"></a></li>
+<li><a target="_blank" rel="noopener noreferrer nofollow" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" title="Optional title attribute" style="max-width: 100%;"></a></li>
+<li><a target="_blank" rel="noopener noreferrer nofollow" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" width="32" height="32" style="max-width: 100%; height: auto; max-height: 32px;"></a>   ← bigger &amp; blurrier</li>
 </ul>
 <h2 dir="auto">Automatic links</h2>
 <ul dir="auto">
@@ -376,19 +376,19 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <h4 dir="auto">Strikethrough</h4>
 <p dir="auto"><del>Mistaken text.</del></p>
 <h4 dir="auto">Fenced code blocks</h4>
-<pre><code>function test() {
+<pre class="notranslate"><code class="notranslate">function test() {
   console.log("notice the blank line before this function?");
 }
 </code></pre>
 <h4 dir="auto">Syntax highlighting</h4>
-<div class="highlight highlight-source-python"><pre><span class="pl-en">print</span>(<span class="pl-s">'Hello!'</span>)</pre></div>
-<div class="highlight highlight-source-js"><pre><span class="pl-smi">console</span><span class="pl-kos">.</span><span class="pl-en">log</span><span class="pl-kos">(</span><span class="pl-s">'JavaScript!'</span><span class="pl-kos">)</span><span class="pl-kos">;</span></pre></div>
-<div class="highlight highlight-source-js"><pre><span class="pl-smi">console</span><span class="pl-kos">.</span><span class="pl-en">log</span><span class="pl-kos">(</span><span class="pl-s">'JavaScript (with js)!'</span><span class="pl-kos">)</span><span class="pl-kos">;</span></pre></div>
-<pre lang="unmatched_language"><code>console.log('No matching language, but looks like JavaScript.');
+<div class="highlight highlight-source-python" dir="auto"><pre class="notranslate"><span class="pl-en">print</span>(<span class="pl-s">'Hello!'</span>)</pre></div>
+<div class="highlight highlight-source-js" dir="auto"><pre class="notranslate"><span class="pl-smi">console</span><span class="pl-kos">.</span><span class="pl-en">log</span><span class="pl-kos">(</span><span class="pl-s">'JavaScript!'</span><span class="pl-kos">)</span><span class="pl-kos">;</span></pre></div>
+<div class="highlight highlight-source-js" dir="auto"><pre class="notranslate"><span class="pl-smi">console</span><span class="pl-kos">.</span><span class="pl-en">log</span><span class="pl-kos">(</span><span class="pl-s">'JavaScript (with js)!'</span><span class="pl-kos">)</span><span class="pl-kos">;</span></pre></div>
+<pre lang="unmatched_language" class="notranslate"><code class="notranslate">console.log('No matching language, but looks like JavaScript.');
 </code></pre>
 <h4 dir="auto">Tables</h4>
 <p dir="auto">Simple:</p>
-<table role="table">
+<markdown-accessiblity-table><table role="table">
 <thead>
 <tr>
 <th>First Header</th>
@@ -405,9 +405,9 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <td>Content Cell</td>
 </tr>
 </tbody>
-</table>
+</table></markdown-accessiblity-table>
 <p dir="auto">Pipes:</p>
-<table role="table">
+<markdown-accessiblity-table><table role="table">
 <thead>
 <tr>
 <th>First Header</th>
@@ -424,9 +424,9 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <td>Content Cell</td>
 </tr>
 </tbody>
-</table>
+</table></markdown-accessiblity-table>
 <p dir="auto">Unmatched:</p>
-<table role="table">
+<markdown-accessiblity-table><table role="table">
 <thead>
 <tr>
 <th>Name</th>
@@ -443,9 +443,9 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <td>Closes a window</td>
 </tr>
 </tbody>
-</table>
+</table></markdown-accessiblity-table>
 <p dir="auto">Inner Markdown:</p>
-<table role="table">
+<markdown-accessiblity-table><table role="table">
 <thead>
 <tr>
 <th>Name</th>
@@ -462,9 +462,9 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <td><em>Closes</em> a window</td>
 </tr>
 </tbody>
-</table>
+</table></markdown-accessiblity-table>
 <p dir="auto">Alignment:</p>
-<table role="table">
+<markdown-accessiblity-table><table role="table">
 <thead>
 <tr>
 <th align="left">Left-Aligned</th>
@@ -494,7 +494,7 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <td align="right"></td>
 </tr>
 </tbody>
-</table>
+</table></markdown-accessiblity-table>
 <h4 dir="auto">HTML</h4>
 <p dir="auto"><em>TODO: Test all allowed HTML tags.</em></p>
 <h2 dir="auto">Writing on GitHub</h2>
@@ -504,21 +504,21 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 Violets are Blue</p>
 <h4 dir="auto">Task lists</h4>
 <ul class="contains-task-list">
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" checked=""> @mentions, #refs, <a href="">links</a>, <strong>formatting</strong>, and <del>tags</del> are supported</li>
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" checked=""> list syntax is required (any unordered or ordered list supported)</li>
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" checked=""> this is a complete item</li>
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox"> this is an incomplete item</li>
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Completed task" checked=""> @mentions, #refs, <a href="">links</a>, <strong>formatting</strong>, and <del>tags</del> are supported</li>
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Completed task" checked=""> list syntax is required (any unordered or ordered list supported)</li>
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Completed task" checked=""> this is a complete item</li>
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Incomplete task"> this is an incomplete item</li>
 </ul>
 <p dir="auto">Task lists can be nested to better structure your tasks:</p>
 <ul class="contains-task-list">
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox"> a bigger project
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Incomplete task"> a bigger project
 <ul class="contains-task-list">
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" checked=""> first subtask #1234</li>
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox"> follow up subtask #4321</li>
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox"> final subtask cc @mention</li>
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Completed task" checked=""> first subtask #1234</li>
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Incomplete task"> follow up subtask #4321</li>
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Incomplete task"> final subtask cc @mention</li>
 </ul>
 </li>
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" checked=""> a separate task</li>
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Completed task" checked=""> a separate task</li>
 </ul>
 <h4 dir="auto">References</h4>
 <ul dir="auto">

--- a/tests/output/app/gfm-test.html
+++ b/tests/output/app/gfm-test.html
@@ -46,17 +46,15 @@
                     
                     <div class="Box-body px-5 pb-5">
                       <article id="grip-content" class="markdown-body entry-content container-lg">
-                        <h1>
-<a id="user-content-github-flavored-markdown-test" class="anchor" href="#github-flavored-markdown-test" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>GitHub Flavored Markdown Test</h1>
+                        <div class="markdown-heading"><h1 class="heading-element">GitHub Flavored Markdown Test</h1><a id="user-content-github-flavored-markdown-test" class="anchor" aria-label="Permalink: GitHub Flavored Markdown Test" href="#github-flavored-markdown-test"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>This Markdown file contains all the features of <strong>GitHub Flavored Markdown</strong> for
 testing a renderer with.</p>
 <p>The features are taken directly from <a href="https://daringfireball.net/projects/markdown/syntax" rel="nofollow">Daring Fireball</a>
 and <a href="https://help.github.com/articles/github-flavored-markdown/">GitHub Flavored Markdown</a>,
 followed by a list of one-offs.</p>
-<h2>
-<a id="user-content-inline-html" class="anchor" href="#inline-html" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Inline HTML</h2>
+<div class="markdown-heading"><h2 class="heading-element">Inline HTML</h2><a id="user-content-inline-html" class="anchor" aria-label="Permalink: Inline HTML" href="#inline-html"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <table>
-  <tr>
+  <tbody><tr>
     <td>Foo</td>
   </tr>
   <tr>
@@ -65,13 +63,12 @@ followed by a list of one-offs.</p>
       E.g., you can’t use Markdown-style *emphasis* inside an HTML block.
     </td>
   </tr>
-</table>
+</tbody></table>
 <p>Span-level HTML tags — e.g. &lt;span&gt;, &lt;cite&gt;, or &lt;del&gt; — can be used anywhere
 in a Markdown paragraph, list item, or header. If you want, you can even use HTML tags instead
 of Markdown formatting; e.g. if you’d prefer to use HTML &lt;a&gt; or &lt;img&gt; tags instead
 of Markdown’s link or image syntax, go right ahead.</p>
-<h4>
-<a id="user-content-testing-span-cite-and-del-tags" class="anchor" href="#testing-span-cite-and-del-tags" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Testing <span>span</span>, cite, and <del>del</del> tags</h4>
+<div class="markdown-heading"><h4 class="heading-element">Testing <span>span</span>, cite, and <del>del</del> tags</h4><a id="user-content-testing-span-cite-and-del-tags" class="anchor" aria-label="Permalink: Testing span, cite, and del tags" href="#testing-span-cite-and-del-tags"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Testing <span>span</span>, cite, and <del>del</del> tags in a paragraph.</p>
 <p>And each element in its own list item:</p>
 <ul>
@@ -79,8 +76,7 @@ of Markdown’s link or image syntax, go right ahead.</p>
 <li>This is within a cite tag.</li>
 <li><del>This is within a del tag.</del></li>
 </ul>
-<h2>
-<a id="user-content-automatic-escaping-for-special-characters" class="anchor" href="#automatic-escaping-for-special-characters" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Automatic escaping for special characters</h2>
+<div class="markdown-heading"><h2 class="heading-element">Automatic escaping for special characters</h2><a id="user-content-automatic-escaping-for-special-characters" class="anchor" aria-label="Permalink: Automatic escaping for special characters" href="#automatic-escaping-for-special-characters"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ul>
 <li>© copyright</li>
 <li>AT&amp;T should render the same as AT&amp;T</li>
@@ -92,8 +88,7 @@ convert <code>&amp;amp;</code>. So these two should yield different links:</p>
 <li><a href="http://images.google.com/images?num=30&amp;q=larry+bird" rel="nofollow">http://images.google.com/images?num=30&amp;q=larry+bird</a></li>
 <li><a href="http://images.google.com/images?num=30&amp;amp;q=larry+bird" rel="nofollow">http://images.google.com/images?num=30&amp;amp;q=larry+bird</a></li>
 </ul>
-<h2>
-<a id="user-content-paragraphs-and-line-breaks" class="anchor" href="#paragraphs-and-line-breaks" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Paragraphs and line breaks</h2>
+<div class="markdown-heading"><h2 class="heading-element">Paragraphs and line breaks</h2><a id="user-content-paragraphs-and-line-breaks" class="anchor" aria-label="Permalink: Paragraphs and line breaks" href="#paragraphs-and-line-breaks"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>This is a normal paragraph.</p>
 <p>This and the next sentence is separated by a single newline.
 This should be on the same line.</p>
@@ -103,36 +98,26 @@ This should be on a new line, directly below.</p>
 This should be two lines below.</p>
 <p>These two paragraphs are separated by two <code>&lt;br /&gt;</code> tags. <br><br></p>
 <p>This should be three lines below.</p>
-<h2>
-<a id="user-content-headers" class="anchor" href="#headers" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Headers</h2>
+<div class="markdown-heading"><h2 class="heading-element">Headers</h2><a id="user-content-headers" class="anchor" aria-label="Permalink: Headers" href="#headers"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Here are some headers followed by <a href="https://en.wikipedia.org/wiki/Lorem_ipsum" rel="nofollow">Lorem Ipsum</a>.</p>
-<h1>
-<a id="user-content-this-is-an-h1-setext-style" class="anchor" href="#this-is-an-h1-setext-style" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>This is an H1 (Setext-style)</h1>
+<div class="markdown-heading"><h1 class="heading-element">This is an H1 (Setext-style)</h1><a id="user-content-this-is-an-h1-setext-style" class="anchor" aria-label="Permalink: This is an H1 (Setext-style)" href="#this-is-an-h1-setext-style"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-<h2>
-<a id="user-content-this-is-an-h2-setext-style" class="anchor" href="#this-is-an-h2-setext-style" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>This is an H2 (Setext-style)</h2>
+<div class="markdown-heading"><h2 class="heading-element">This is an H2 (Setext-style)</h2><a id="user-content-this-is-an-h2-setext-style" class="anchor" aria-label="Permalink: This is an H2 (Setext-style)" href="#this-is-an-h2-setext-style"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 <p>The following are atx-style.</p>
-<h1>
-<a id="user-content-this-is-an-h1" class="anchor" href="#this-is-an-h1" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>This is an H1</h1>
+<div class="markdown-heading"><h1 class="heading-element">This is an H1</h1><a id="user-content-this-is-an-h1" class="anchor" aria-label="Permalink: This is an H1" href="#this-is-an-h1"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-<h2>
-<a id="user-content-this-is-an-h2" class="anchor" href="#this-is-an-h2" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>This is an H2</h2>
+<div class="markdown-heading"><h2 class="heading-element">This is an H2</h2><a id="user-content-this-is-an-h2" class="anchor" aria-label="Permalink: This is an H2" href="#this-is-an-h2"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Mauris feugiat, augue vitae sollicitudin vulputate, neque arcu dapibus eros, eget semper lorem ex rhoncus nulla.</p>
-<h3>
-<a id="user-content-this-is-an-h3" class="anchor" href="#this-is-an-h3" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>This is an H3</h3>
+<div class="markdown-heading"><h3 class="heading-element">This is an H3</h3><a id="user-content-this-is-an-h3" class="anchor" aria-label="Permalink: This is an H3" href="#this-is-an-h3"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Etiam sit amet orci sit amet dui mollis molestie.</p>
-<h4>
-<a id="user-content-this-is-an-h4" class="anchor" href="#this-is-an-h4" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>This is an H4</h4>
+<div class="markdown-heading"><h4 class="heading-element">This is an H4</h4><a id="user-content-this-is-an-h4" class="anchor" aria-label="Permalink: This is an H4" href="#this-is-an-h4"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Cras et elit egestas, lacinia est eu, vestibulum enim.</p>
-<h5>
-<a id="user-content-this-is-an-h5" class="anchor" href="#this-is-an-h5" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>This is an H5</h5>
+<div class="markdown-heading"><h5 class="heading-element">This is an H5</h5><a id="user-content-this-is-an-h5" class="anchor" aria-label="Permalink: This is an H5" href="#this-is-an-h5"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Phasellus sed suscipit quam.</p>
-<h6>
-<a id="user-content-this-is-an-h36" class="anchor" href="#this-is-an-h36" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>This is an H√36</h6>
+<div class="markdown-heading"><h6 class="heading-element">This is an H√36</h6><a id="user-content-this-is-an-h36" class="anchor" aria-label="Permalink: This is an H√36" href="#this-is-an-h36"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Nam rutrum imperdiet purus, sit amet porttitor augue tempor quis.</p>
-<h2>
-<a id="user-content-blockquotes" class="anchor" href="#blockquotes" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Blockquotes</h2>
+<div class="markdown-heading"><h2 class="heading-element">Blockquotes</h2><a id="user-content-blockquotes" class="anchor" aria-label="Permalink: Blockquotes" href="#blockquotes"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Email-style blockquotes:</p>
 <blockquote>
 <p>This is a blockquote with two paragraphs. Lorem ipsum dolor sit amet,
@@ -161,8 +146,7 @@ id sem consectetuer libero luctus adipiscing.</p>
 </blockquote>
 <p>Blockquotes containing other Markdown elements:</p>
 <blockquote>
-<h2>
-<a id="user-content-this-is-a-header" class="anchor" href="#this-is-a-header" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>This is a header.</h2>
+<div class="markdown-heading"><h2 class="heading-element">This is a header.</h2><a id="user-content-this-is-a-header" class="anchor" aria-label="Permalink: This is a header." href="#this-is-a-header"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ol>
 <li>This is the first list item.</li>
 <li>This is the second list item.</li>
@@ -171,10 +155,8 @@ id sem consectetuer libero luctus adipiscing.</p>
 <pre><code>return shell_exec("echo $input | $markdown_script");
 </code></pre>
 </blockquote>
-<h2>
-<a id="user-content-lists" class="anchor" href="#lists" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Lists</h2>
-<h5>
-<a id="user-content-these-three-lists-should-be-equivalent" class="anchor" href="#these-three-lists-should-be-equivalent" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>These three lists should be equivalent</h5>
+<div class="markdown-heading"><h2 class="heading-element">Lists</h2><a id="user-content-lists" class="anchor" aria-label="Permalink: Lists" href="#lists"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
+<div class="markdown-heading"><h5 class="heading-element">These three lists should be equivalent</h5><a id="user-content-these-three-lists-should-be-equivalent" class="anchor" aria-label="Permalink: These three lists should be equivalent" href="#these-three-lists-should-be-equivalent"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>First:</p>
 <ul>
 <li>Red</li>
@@ -193,8 +175,7 @@ id sem consectetuer libero luctus adipiscing.</p>
 <li>Green</li>
 <li>Blue</li>
 </ul>
-<h4>
-<a id="user-content-these-three-ordered-lists-should-be-equivalent" class="anchor" href="#these-three-ordered-lists-should-be-equivalent" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>These three ordered lists should be equivalent</h4>
+<div class="markdown-heading"><h4 class="heading-element">These three ordered lists should be equivalent</h4><a id="user-content-these-three-ordered-lists-should-be-equivalent" class="anchor" aria-label="Permalink: These three ordered lists should be equivalent" href="#these-three-ordered-lists-should-be-equivalent"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>First:</p>
 <ol>
 <li>Bird</li>
@@ -213,8 +194,7 @@ id sem consectetuer libero luctus adipiscing.</p>
 <li>McHale</li>
 <li>Parish</li>
 </ol>
-<h4>
-<a id="user-content-these-two-lists-should-be-equivalent" class="anchor" href="#these-two-lists-should-be-equivalent" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>These two lists should be equivalent</h4>
+<div class="markdown-heading"><h4 class="heading-element">These two lists should be equivalent</h4><a id="user-content-these-two-lists-should-be-equivalent" class="anchor" aria-label="Permalink: These two lists should be equivalent" href="#these-two-lists-should-be-equivalent"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>First:</p>
 <ul>
 <li>Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
@@ -231,8 +211,7 @@ viverra nec, fringilla in, laoreet vitae, risus.</li>
 <li>Donec sit amet nisl. Aliquam semper ipsum sit amet velit.
 Suspendisse id sem consectetuer libero luctus adipiscing.</li>
 </ul>
-<h4>
-<a id="user-content-paragraphs-and-lists" class="anchor" href="#paragraphs-and-lists" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Paragraphs and lists</h4>
+<div class="markdown-heading"><h4 class="heading-element">Paragraphs and lists</h4><a id="user-content-paragraphs-and-lists" class="anchor" aria-label="Permalink: Paragraphs and lists" href="#paragraphs-and-lists"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ul>
 <li>Bird</li>
 <li>Magic</li>
@@ -246,8 +225,7 @@ Suspendisse id sem consectetuer libero luctus adipiscing.</li>
 <p>Magic</p>
 </li>
 </ul>
-<h4>
-<a id="user-content-paragraphs-within-lists" class="anchor" href="#paragraphs-within-lists" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Paragraphs within lists</h4>
+<div class="markdown-heading"><h4 class="heading-element">Paragraphs within lists</h4><a id="user-content-paragraphs-within-lists" class="anchor" aria-label="Permalink: Paragraphs within lists" href="#paragraphs-within-lists"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>First:</p>
 <ol>
 <li>
@@ -274,8 +252,7 @@ sit amet, consectetuer adipiscing elit.</p>
 <p>Another item in the same list.</p>
 </li>
 </ul>
-<h4>
-<a id="user-content-blockquote-within-a-list" class="anchor" href="#blockquote-within-a-list" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Blockquote within a list</h4>
+<div class="markdown-heading"><h4 class="heading-element">Blockquote within a list</h4><a id="user-content-blockquote-within-a-list" class="anchor" aria-label="Permalink: Blockquote within a list" href="#blockquote-within-a-list"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ul>
 <li>
 <p>A list item with a blockquote:</p>
@@ -285,8 +262,7 @@ inside a list item.</p>
 </blockquote>
 </li>
 </ul>
-<h4>
-<a id="user-content-code-within-a-list" class="anchor" href="#code-within-a-list" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Code within a list</h4>
+<div class="markdown-heading"><h4 class="heading-element">Code within a list</h4><a id="user-content-code-within-a-list" class="anchor" aria-label="Permalink: Code within a list" href="#code-within-a-list"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ul>
 <li>
 <p>A list item with a code block:</p>
@@ -294,14 +270,12 @@ inside a list item.</p>
 </code></pre>
 </li>
 </ul>
-<h4>
-<a id="user-content-accidental-lists" class="anchor" href="#accidental-lists" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Accidental lists</h4>
+<div class="markdown-heading"><h4 class="heading-element">Accidental lists</h4><a id="user-content-accidental-lists" class="anchor" aria-label="Permalink: Accidental lists" href="#accidental-lists"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ol start="1986">
 <li>What a great season. (oops, I wanted a year, not a list)</li>
 </ol>
 <p>1986. What a great season. (<em>whew!</em> there we go)</p>
-<h2>
-<a id="user-content-code-blocks" class="anchor" href="#code-blocks" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Code blocks</h2>
+<div class="markdown-heading"><h2 class="heading-element">Code blocks</h2><a id="user-content-code-blocks" class="anchor" aria-label="Permalink: Code blocks" href="#code-blocks"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>This is a normal paragraph:</p>
 <pre><code>This is a code block.
 </code></pre>
@@ -323,18 +297,15 @@ end
 <code>
 print('Code block')
 </code>
-<pre>
-print('Pre block')
+<pre>print('Pre block')
 </pre>
-<h2>
-<a id="user-content-horizontal-rules" class="anchor" href="#horizontal-rules" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Horizontal rules</h2>
+<div class="markdown-heading"><h2 class="heading-element">Horizontal rules</h2><a id="user-content-horizontal-rules" class="anchor" aria-label="Permalink: Horizontal rules" href="#horizontal-rules"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <hr>
 <hr>
 <hr>
 <hr>
 <hr>
-<h2>
-<a id="user-content-links" class="anchor" href="#links" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Links</h2>
+<div class="markdown-heading"><h2 class="heading-element">Links</h2><a id="user-content-links" class="anchor" aria-label="Permalink: Links" href="#links"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Markdown supports two style of links: inline and reference.</p>
 <p>This is <a href="http://joeyespo.com/" title="Title" rel="nofollow">an example</a> inline link.</p>
 <p><a href="http://joeyespo.com/" rel="nofollow">This link</a> has no title attribute.</p>
@@ -349,8 +320,7 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <li><a href="http://joeyespo.com/" title="Optional Title Here" rel="nofollow">foo 4</a></li>
 <li><a href="http://joeyespo.com/" title="Optional Title Here" rel="nofollow">foo 5</a></li>
 </ul>
-<h2>
-<a id="user-content-emphasis" class="anchor" href="#emphasis" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Emphasis</h2>
+<div class="markdown-heading"><h2 class="heading-element">Emphasis</h2><a id="user-content-emphasis" class="anchor" aria-label="Permalink: Emphasis" href="#emphasis"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ul>
 <li><em>single asterisks</em></li>
 <li><em>single underscores</em></li>
@@ -359,8 +329,7 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <li>un<em>frigging</em>believable</li>
 <li>*this text is surrounded by literal asterisks*</li>
 </ul>
-<h2>
-<a id="user-content-code" class="anchor" href="#code" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Code</h2>
+<div class="markdown-heading"><h2 class="heading-element">Code</h2><a id="user-content-code" class="anchor" aria-label="Permalink: Code" href="#code"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ul>
 <li>Use the <code>printf()</code> function.</li>
 <li><code>There is a literal backtick (`) here.</code></li>
@@ -373,23 +342,20 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <code>&amp;#8212;</code> is the decimal-encoded equivalent of <code>&amp;mdash;</code>
 </li>
 </ul>
-<h2>
-<a id="user-content-images" class="anchor" href="#images" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Images</h2>
+<div class="markdown-heading"><h2 class="heading-element">Images</h2><a id="user-content-images" class="anchor" aria-label="Permalink: Images" href="#images"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ul>
-<li><a href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" target="_blank" rel="nofollow"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" style="max-width:100%;"></a></li>
-<li><a href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" target="_blank" rel="nofollow"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" title="Optional title" style="max-width:100%;"></a></li>
-<li><a href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" target="_blank" rel="nofollow"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" title="Optional title attribute" style="max-width:100%;"></a></li>
+<li><a target="_blank" rel="noopener noreferrer nofollow" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" style="max-width: 100%;"></a></li>
+<li><a target="_blank" rel="noopener noreferrer nofollow" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" title="Optional title" style="max-width: 100%;"></a></li>
+<li><a target="_blank" rel="noopener noreferrer nofollow" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" title="Optional title attribute" style="max-width: 100%;"></a></li>
 <li>
-<a href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" target="_blank" rel="nofollow"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" width="32" height="32" style="max-width:100%;"></a>   ← bigger &amp; blurrier</li>
+<a target="_blank" rel="noopener noreferrer nofollow" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" width="32" height="32" style="max-width: 100%; height: auto; max-height: 32px;"></a>   ← bigger &amp; blurrier</li>
 </ul>
-<h2>
-<a id="user-content-automatic-links" class="anchor" href="#automatic-links" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Automatic links</h2>
+<div class="markdown-heading"><h2 class="heading-element">Automatic links</h2><a id="user-content-automatic-links" class="anchor" aria-label="Permalink: Automatic links" href="#automatic-links"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ul>
 <li><a href="http://joeyespo.com/" rel="nofollow">http://joeyespo.com/</a></li>
 <li><a href="mailto:joe@joeyespo.com">joe@joeyespo.com</a></li>
 </ul>
-<h2>
-<a id="user-content-backslash-escapes" class="anchor" href="#backslash-escapes" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Backslash escapes</h2>
+<div class="markdown-heading"><h2 class="heading-element">Backslash escapes</h2><a id="user-content-backslash-escapes" class="anchor" aria-label="Permalink: Backslash escapes" href="#backslash-escapes"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ul>
 <li>*literal asterisks*</li>
 <li>\   backslash</li>
@@ -405,35 +371,28 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <li>.   dot</li>
 <li>!   exclamation mark</li>
 </ul>
-<h2>
-<a id="user-content-github-flavored-markdown" class="anchor" href="#github-flavored-markdown" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>GitHub Flavored Markdown</h2>
+<div class="markdown-heading"><h2 class="heading-element">GitHub Flavored Markdown</h2><a id="user-content-github-flavored-markdown" class="anchor" aria-label="Permalink: GitHub Flavored Markdown" href="#github-flavored-markdown"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>See <a href="https://help.github.com/articles/github-flavored-markdown/">GitHub Flavored Markdown</a> for details.</p>
-<h4>
-<a id="user-content-multiple-underscores-in-words" class="anchor" href="#multiple-underscores-in-words" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Multiple underscores in words</h4>
+<div class="markdown-heading"><h4 class="heading-element">Multiple underscores in words</h4><a id="user-content-multiple-underscores-in-words" class="anchor" aria-label="Permalink: Multiple underscores in words" href="#multiple-underscores-in-words"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ul>
 <li>wow_great_stuff</li>
 </ul>
-<h4>
-<a id="user-content-url-autolinking" class="anchor" href="#url-autolinking" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>URL autolinking</h4>
+<div class="markdown-heading"><h4 class="heading-element">URL autolinking</h4><a id="user-content-url-autolinking" class="anchor" aria-label="Permalink: URL autolinking" href="#url-autolinking"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p><a href="http://joeyespo.com" rel="nofollow">http://joeyespo.com</a></p>
-<h4>
-<a id="user-content-strikethrough" class="anchor" href="#strikethrough" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Strikethrough</h4>
+<div class="markdown-heading"><h4 class="heading-element">Strikethrough</h4><a id="user-content-strikethrough" class="anchor" aria-label="Permalink: Strikethrough" href="#strikethrough"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p><del>Mistaken text.</del></p>
-<h4>
-<a id="user-content-fenced-code-blocks" class="anchor" href="#fenced-code-blocks" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Fenced code blocks</h4>
+<div class="markdown-heading"><h4 class="heading-element">Fenced code blocks</h4><a id="user-content-fenced-code-blocks" class="anchor" aria-label="Permalink: Fenced code blocks" href="#fenced-code-blocks"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <pre><code>function test() {
   console.log("notice the blank line before this function?");
 }
 </code></pre>
-<h4>
-<a id="user-content-syntax-highlighting" class="anchor" href="#syntax-highlighting" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Syntax highlighting</h4>
+<div class="markdown-heading"><h4 class="heading-element">Syntax highlighting</h4><a id="user-content-syntax-highlighting" class="anchor" aria-label="Permalink: Syntax highlighting" href="#syntax-highlighting"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <div class="highlight highlight-source-python"><pre><span class="pl-en">print</span>(<span class="pl-s">'Hello!'</span>)</pre></div>
 <div class="highlight highlight-source-js"><pre><span class="pl-smi">console</span><span class="pl-kos">.</span><span class="pl-en">log</span><span class="pl-kos">(</span><span class="pl-s">'JavaScript!'</span><span class="pl-kos">)</span><span class="pl-kos">;</span></pre></div>
 <div class="highlight highlight-source-js"><pre><span class="pl-smi">console</span><span class="pl-kos">.</span><span class="pl-en">log</span><span class="pl-kos">(</span><span class="pl-s">'JavaScript (with js)!'</span><span class="pl-kos">)</span><span class="pl-kos">;</span></pre></div>
 <pre lang="unmatched_language"><code>console.log('No matching language, but looks like JavaScript.');
 </code></pre>
-<h4>
-<a id="user-content-tables" class="anchor" href="#tables" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Tables</h4>
+<div class="markdown-heading"><h4 class="heading-element">Tables</h4><a id="user-content-tables" class="anchor" aria-label="Permalink: Tables" href="#tables"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Simple:</p>
 <table>
 <thead>
@@ -544,18 +503,14 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 </tr>
 </tbody>
 </table>
-<h4>
-<a id="user-content-html" class="anchor" href="#html" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>HTML</h4>
+<div class="markdown-heading"><h4 class="heading-element">HTML</h4><a id="user-content-html" class="anchor" aria-label="Permalink: HTML" href="#html"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p><em>TODO: Test all allowed HTML tags.</em></p>
-<h2>
-<a id="user-content-writing-on-github" class="anchor" href="#writing-on-github" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Writing on GitHub</h2>
+<div class="markdown-heading"><h2 class="heading-element">Writing on GitHub</h2><a id="user-content-writing-on-github" class="anchor" aria-label="Permalink: Writing on GitHub" href="#writing-on-github"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>See <a href="https://help.github.com/articles/writing-on-github/">this article</a> for details.</p>
-<h4>
-<a id="user-content-newlines" class="anchor" href="#newlines" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Newlines</h4>
+<div class="markdown-heading"><h4 class="heading-element">Newlines</h4><a id="user-content-newlines" class="anchor" aria-label="Permalink: Newlines" href="#newlines"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Roses are red
 Violets are Blue</p>
-<h4>
-<a id="user-content-task-lists" class="anchor" href="#task-lists" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Task lists</h4>
+<div class="markdown-heading"><h4 class="heading-element">Task lists</h4><a id="user-content-task-lists" class="anchor" aria-label="Permalink: Task lists" href="#task-lists"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ul>
 <li class="task-list-item"><input type="checkbox" class="task-list-item-checkbox" checked="" disabled=""> @mentions, #refs, <a href="">links</a>, <strong>formatting</strong>, and <del>tags</del> are supported</li>
 <li class="task-list-item"><input type="checkbox" class="task-list-item-checkbox" checked="" disabled=""> list syntax is required (any unordered or ordered list supported)</li>
@@ -573,8 +528,7 @@ Violets are Blue</p>
 </li>
 <li class="task-list-item"><input type="checkbox" class="task-list-item-checkbox" checked="" disabled=""> a separate task</li>
 </ul>
-<h4>
-<a id="user-content-references" class="anchor" href="#references" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>References</h4>
+<div class="markdown-heading"><h4 class="heading-element">References</h4><a id="user-content-references" class="anchor" aria-label="Permalink: References" href="#references"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ul>
 <li>SHA: dbcd7a410ee7489acf92f40641a135fbcf52a768</li>
 <li>User@SHA: joeyespo@dbcd7a410ee7489acf92f40641a135fbcf52a768</li>

--- a/tests/output/app/simple.html
+++ b/tests/output/app/simple.html
@@ -46,8 +46,7 @@
                     
                     <div class="Box-body px-5 pb-5">
                       <article id="grip-content" class="markdown-body entry-content container-lg">
-                        <h1>
-<a id="user-content-simple-test-" class="anchor" href="#simple-test-" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Simple Test ✓</h1>
+                        <div class="markdown-heading"><h1 class="heading-element">Simple Test ✓</h1><a id="user-content-simple-test-" class="anchor" aria-label="Permalink: Simple Test ✓" href="#simple-test-"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>This is just a simple Unicode Markdown test.</p>
 
                       </article>

--- a/tests/output/raw/gfm-test-user-content.html
+++ b/tests/output/raw/gfm-test-user-content.html
@@ -5,7 +5,7 @@ testing a renderer with.</p>
 and <a href="https://help.github.com/articles/github-flavored-markdown/">GitHub Flavored Markdown</a>,<br>
 followed by a list of one-offs.</p>
 <h2>Inline HTML</h2>
-<table role="table">
+<markdown-accessiblity-table><table role="table">
   <tbody><tr>
     <td>Foo</td>
   </tr>
@@ -15,7 +15,7 @@ followed by a list of one-offs.</p>
       E.g., you can’t use Markdown-style *emphasis* inside an HTML block.
     </td>
   </tr>
-</tbody></table>
+</tbody></table></markdown-accessiblity-table>
 <p>Span-level HTML tags — e.g. &lt;span&gt;, &lt;cite&gt;, or &lt;del&gt; — can be used anywhere<br>
 in a Markdown paragraph, list item, or header. If you want, you can even use HTML tags instead<br>
 of Markdown formatting; e.g. if you’d prefer to use HTML &lt;a&gt; or &lt;img&gt; tags instead<br>
@@ -35,7 +35,7 @@ of Markdown’s link or image syntax, go right ahead.</p>
 <li>4 &lt; 5 should render the same as 4 &lt; 5</li>
 </ul>
 <p>Note that GitHub Flavored Markdown has URL autolinking, which will <em>not</em><br>
-convert <code>&amp;amp;</code>. So these two should yield different links:</p>
+convert <code class="notranslate">&amp;amp;</code>. So these two should yield different links:</p>
 <ul>
 <li><a href="http://images.google.com/images?num=30&amp;q=larry+bird" rel="nofollow">http://images.google.com/images?num=30&amp;q=larry+bird</a></li>
 <li><a href="http://images.google.com/images?num=30&amp;amp;q=larry+bird" rel="nofollow">http://images.google.com/images?num=30&amp;amp;q=larry+bird</a></li>
@@ -44,11 +44,11 @@ convert <code>&amp;amp;</code>. So these two should yield different links:</p>
 <p>This is a normal paragraph.</p>
 <p>This and the next sentence is separated by a single newline.<br>
 This should be on the same line.</p>
-<p>This and the next sentence is joined by a single <code>&lt;br /&gt;</code>. <br><br>
+<p>This and the next sentence is joined by a single <code class="notranslate">&lt;br /&gt;</code>. <br><br>
 This should be on a new line, directly below.</p>
-<p>These two sentences are separated by two <code>&lt;br /&gt;</code> tags. <br><br><br>
+<p>These two sentences are separated by two <code class="notranslate">&lt;br /&gt;</code> tags. <br><br><br>
 This should be two lines below.</p>
-<p>These two paragraphs are separated by two <code>&lt;br /&gt;</code> tags. <br><br></p>
+<p>These two paragraphs are separated by two <code class="notranslate">&lt;br /&gt;</code> tags. <br><br></p>
 <p>This should be three lines below.</p>
 <h2>Headers</h2>
 <p>Here are some headers followed by <a href="https://en.wikipedia.org/wiki/Lorem_ipsum" rel="nofollow">Lorem Ipsum</a>.</p>
@@ -104,7 +104,7 @@ id sem consectetuer libero luctus adipiscing.</p>
 <li>This is the second list item.</li>
 </ol>
 <p>Here's some example code:</p>
-<pre><code>return shell_exec("echo $input | $markdown_script");
+<pre class="notranslate"><code class="notranslate">return shell_exec("echo $input | $markdown_script");
 </code></pre>
 </blockquote>
 <h2>Lists</h2>
@@ -218,7 +218,7 @@ inside a list item.</p>
 <ul>
 <li>
 <p>A list item with a code block:</p>
-<pre><code>&lt;code goes here&gt;
+<pre class="notranslate"><code class="notranslate">&lt;code goes here&gt;
 </code></pre>
 </li>
 </ul>
@@ -229,15 +229,15 @@ inside a list item.</p>
 <p>1986. What a great season. (<em>whew!</em> there we go)</p>
 <h2>Code blocks</h2>
 <p>This is a normal paragraph:</p>
-<pre><code>This is a code block.
+<pre class="notranslate"><code class="notranslate">This is a code block.
 </code></pre>
 <p>Here is an example of AppleScript:</p>
-<pre><code>tell application "Foo"
+<pre class="notranslate"><code class="notranslate">tell application "Foo"
     beep
 end tell
 </code></pre>
 <p>Markdown will handle the hassle of encoding the ampersands and angle brackets:</p>
-<pre><code>&lt;div class="footer"&gt;
+<pre class="notranslate"><code class="notranslate">&lt;div class="footer"&gt;
     &amp;copy; 2004 Foo Corporation
 &lt;/div&gt;
 
@@ -246,10 +246,10 @@ def this_is
   puts "some #{4-space-indent} code"
 end
 </code></pre>
-<code>
+<code class="notranslate">
 print('Code block')
 </code>
-<pre>print('Pre block')
+<pre class="notranslate">print('Pre block')
 </pre>
 <h2>Horizontal rules</h2>
 <hr>
@@ -283,19 +283,19 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 </ul>
 <h2>Code</h2>
 <ul>
-<li>Use the <code>printf()</code> function.</li>
-<li><code>There is a literal backtick (`) here.</code></li>
-<li>A single backtick in a code span: <code>`</code></li>
-<li>A backtick-delimited string in a code span: <code>`foo`</code></li>
-<li>Please don't use any <code>&lt;blink&gt;</code> tags.</li>
-<li><code>&amp;#8212;</code> is the decimal-encoded equivalent of <code>&amp;mdash;</code></li>
+<li>Use the <code class="notranslate">printf()</code> function.</li>
+<li><code class="notranslate">There is a literal backtick (`) here.</code></li>
+<li>A single backtick in a code span: <code class="notranslate">`</code></li>
+<li>A backtick-delimited string in a code span: <code class="notranslate">`foo`</code></li>
+<li>Please don't use any <code class="notranslate">&lt;blink&gt;</code> tags.</li>
+<li><code class="notranslate">&amp;#8212;</code> is the decimal-encoded equivalent of <code class="notranslate">&amp;mdash;</code></li>
 </ul>
 <h2>Images</h2>
 <ul>
-<li><a target="_blank" rel="noopener noreferrer" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" style="max-width: 100%;"></a></li>
-<li><a target="_blank" rel="noopener noreferrer" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" title="Optional title" style="max-width: 100%;"></a></li>
-<li><a target="_blank" rel="noopener noreferrer" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" title="Optional title attribute" style="max-width: 100%;"></a></li>
-<li><a target="_blank" rel="noopener noreferrer" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" width="32" height="32" style="max-width: 100%;"></a>   ← bigger &amp; blurrier</li>
+<li><a target="_blank" rel="noopener noreferrer nofollow" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" style="max-width: 100%;"></a></li>
+<li><a target="_blank" rel="noopener noreferrer nofollow" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" title="Optional title" style="max-width: 100%;"></a></li>
+<li><a target="_blank" rel="noopener noreferrer nofollow" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" title="Optional title attribute" style="max-width: 100%;"></a></li>
+<li><a target="_blank" rel="noopener noreferrer nofollow" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" width="32" height="32" style="max-width: 100%; height: auto; max-height: 32px;"></a>   ← bigger &amp; blurrier</li>
 </ul>
 <h2>Automatic links</h2>
 <ul>
@@ -329,19 +329,19 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <h4>Strikethrough</h4>
 <p><del>Mistaken text.</del></p>
 <h4>Fenced code blocks</h4>
-<pre><code>function test() {
+<pre class="notranslate"><code class="notranslate">function test() {
   console.log("notice the blank line before this function?");
 }
 </code></pre>
 <h4>Syntax highlighting</h4>
-<div class="highlight highlight-source-python"><pre><span class="pl-en">print</span>(<span class="pl-s">'Hello!'</span>)</pre></div>
-<div class="highlight highlight-source-js"><pre><span class="pl-smi">console</span><span class="pl-kos">.</span><span class="pl-en">log</span><span class="pl-kos">(</span><span class="pl-s">'JavaScript!'</span><span class="pl-kos">)</span><span class="pl-kos">;</span></pre></div>
-<div class="highlight highlight-source-js"><pre><span class="pl-smi">console</span><span class="pl-kos">.</span><span class="pl-en">log</span><span class="pl-kos">(</span><span class="pl-s">'JavaScript (with js)!'</span><span class="pl-kos">)</span><span class="pl-kos">;</span></pre></div>
-<pre lang="unmatched_language"><code>console.log('No matching language, but looks like JavaScript.');
+<div class="highlight highlight-source-python"><pre class="notranslate"><span class="pl-en">print</span>(<span class="pl-s">'Hello!'</span>)</pre></div>
+<div class="highlight highlight-source-js"><pre class="notranslate"><span class="pl-smi">console</span><span class="pl-kos">.</span><span class="pl-en">log</span><span class="pl-kos">(</span><span class="pl-s">'JavaScript!'</span><span class="pl-kos">)</span><span class="pl-kos">;</span></pre></div>
+<div class="highlight highlight-source-js"><pre class="notranslate"><span class="pl-smi">console</span><span class="pl-kos">.</span><span class="pl-en">log</span><span class="pl-kos">(</span><span class="pl-s">'JavaScript (with js)!'</span><span class="pl-kos">)</span><span class="pl-kos">;</span></pre></div>
+<pre lang="unmatched_language" class="notranslate"><code class="notranslate">console.log('No matching language, but looks like JavaScript.');
 </code></pre>
 <h4>Tables</h4>
 <p>Simple:</p>
-<table role="table">
+<markdown-accessiblity-table><table role="table">
 <thead>
 <tr>
 <th>First Header</th>
@@ -358,9 +358,9 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <td>Content Cell</td>
 </tr>
 </tbody>
-</table>
+</table></markdown-accessiblity-table>
 <p>Pipes:</p>
-<table role="table">
+<markdown-accessiblity-table><table role="table">
 <thead>
 <tr>
 <th>First Header</th>
@@ -377,9 +377,9 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <td>Content Cell</td>
 </tr>
 </tbody>
-</table>
+</table></markdown-accessiblity-table>
 <p>Unmatched:</p>
-<table role="table">
+<markdown-accessiblity-table><table role="table">
 <thead>
 <tr>
 <th>Name</th>
@@ -396,9 +396,9 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <td>Closes a window</td>
 </tr>
 </tbody>
-</table>
+</table></markdown-accessiblity-table>
 <p>Inner Markdown:</p>
-<table role="table">
+<markdown-accessiblity-table><table role="table">
 <thead>
 <tr>
 <th>Name</th>
@@ -415,9 +415,9 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <td><em>Closes</em> a window</td>
 </tr>
 </tbody>
-</table>
+</table></markdown-accessiblity-table>
 <p>Alignment:</p>
-<table role="table">
+<markdown-accessiblity-table><table role="table">
 <thead>
 <tr>
 <th align="left">Left-Aligned</th>
@@ -447,7 +447,7 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <td align="right"></td>
 </tr>
 </tbody>
-</table>
+</table></markdown-accessiblity-table>
 <h4>HTML</h4>
 <p><em>TODO: Test all allowed HTML tags.</em></p>
 <h2>Writing on GitHub</h2>
@@ -457,21 +457,21 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 Violets are Blue</p>
 <h4>Task lists</h4>
 <ul class="contains-task-list">
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" checked=""> @mentions, #refs, <a href="">links</a>, <strong>formatting</strong>, and <del>tags</del> are supported</li>
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" checked=""> list syntax is required (any unordered or ordered list supported)</li>
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" checked=""> this is a complete item</li>
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox"> this is an incomplete item</li>
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Completed task" checked=""> @mentions, #refs, <a href="">links</a>, <strong>formatting</strong>, and <del>tags</del> are supported</li>
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Completed task" checked=""> list syntax is required (any unordered or ordered list supported)</li>
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Completed task" checked=""> this is a complete item</li>
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Incomplete task"> this is an incomplete item</li>
 </ul>
 <p>Task lists can be nested to better structure your tasks:</p>
 <ul class="contains-task-list">
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox"> a bigger project
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Incomplete task"> a bigger project
 <ul class="contains-task-list">
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" checked=""> first subtask #1234</li>
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox"> follow up subtask #4321</li>
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox"> final subtask cc @mention</li>
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Completed task" checked=""> first subtask #1234</li>
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Incomplete task"> follow up subtask #4321</li>
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Incomplete task"> final subtask cc @mention</li>
 </ul>
 </li>
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" checked=""> a separate task</li>
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Completed task" checked=""> a separate task</li>
 </ul>
 <h4>References</h4>
 <ul>

--- a/tests/output/raw/gfm-test-user-context.html
+++ b/tests/output/raw/gfm-test-user-context.html
@@ -5,7 +5,7 @@ testing a renderer with.</p>
 and <a href="https://help.github.com/articles/github-flavored-markdown/">GitHub Flavored Markdown</a>,<br>
 followed by a list of one-offs.</p>
 <h2 dir="auto">Inline HTML</h2>
-<table role="table">
+<markdown-accessiblity-table><table role="table">
   <tbody><tr>
     <td>Foo</td>
   </tr>
@@ -15,7 +15,7 @@ followed by a list of one-offs.</p>
       E.g., you can’t use Markdown-style *emphasis* inside an HTML block.
     </td>
   </tr>
-</tbody></table>
+</tbody></table></markdown-accessiblity-table>
 <p dir="auto">Span-level HTML tags — e.g. &lt;span&gt;, &lt;cite&gt;, or &lt;del&gt; — can be used anywhere<br>
 in a Markdown paragraph, list item, or header. If you want, you can even use HTML tags instead<br>
 of Markdown formatting; e.g. if you’d prefer to use HTML &lt;a&gt; or &lt;img&gt; tags instead<br>
@@ -35,7 +35,7 @@ of Markdown’s link or image syntax, go right ahead.</p>
 <li>4 &lt; 5 should render the same as 4 &lt; 5</li>
 </ul>
 <p dir="auto">Note that GitHub Flavored Markdown has URL autolinking, which will <em>not</em><br>
-convert <code>&amp;amp;</code>. So these two should yield different links:</p>
+convert <code class="notranslate">&amp;amp;</code>. So these two should yield different links:</p>
 <ul dir="auto">
 <li><a href="http://images.google.com/images?num=30&amp;q=larry+bird" rel="nofollow">http://images.google.com/images?num=30&amp;q=larry+bird</a></li>
 <li><a href="http://images.google.com/images?num=30&amp;amp;q=larry+bird" rel="nofollow">http://images.google.com/images?num=30&amp;amp;q=larry+bird</a></li>
@@ -44,11 +44,11 @@ convert <code>&amp;amp;</code>. So these two should yield different links:</p>
 <p dir="auto">This is a normal paragraph.</p>
 <p dir="auto">This and the next sentence is separated by a single newline.<br>
 This should be on the same line.</p>
-<p dir="auto">This and the next sentence is joined by a single <code>&lt;br /&gt;</code>. <br><br>
+<p dir="auto">This and the next sentence is joined by a single <code class="notranslate">&lt;br /&gt;</code>. <br><br>
 This should be on a new line, directly below.</p>
-<p dir="auto">These two sentences are separated by two <code>&lt;br /&gt;</code> tags. <br><br><br>
+<p dir="auto">These two sentences are separated by two <code class="notranslate">&lt;br /&gt;</code> tags. <br><br><br>
 This should be two lines below.</p>
-<p dir="auto">These two paragraphs are separated by two <code>&lt;br /&gt;</code> tags. <br><br></p>
+<p dir="auto">These two paragraphs are separated by two <code class="notranslate">&lt;br /&gt;</code> tags. <br><br></p>
 <p dir="auto">This should be three lines below.</p>
 <h2 dir="auto">Headers</h2>
 <p dir="auto">Here are some headers followed by <a href="https://en.wikipedia.org/wiki/Lorem_ipsum" rel="nofollow">Lorem Ipsum</a>.</p>
@@ -104,7 +104,7 @@ id sem consectetuer libero luctus adipiscing.</p>
 <li>This is the second list item.</li>
 </ol>
 <p dir="auto">Here's some example code:</p>
-<pre><code>return shell_exec("echo $input | $markdown_script");
+<pre class="notranslate"><code class="notranslate">return shell_exec("echo $input | $markdown_script");
 </code></pre>
 </blockquote>
 <h2 dir="auto">Lists</h2>
@@ -218,7 +218,7 @@ inside a list item.</p>
 <ul dir="auto">
 <li>
 <p dir="auto">A list item with a code block:</p>
-<pre><code>&lt;code goes here&gt;
+<pre class="notranslate"><code class="notranslate">&lt;code goes here&gt;
 </code></pre>
 </li>
 </ul>
@@ -229,15 +229,15 @@ inside a list item.</p>
 <p dir="auto">1986. What a great season. (<em>whew!</em> there we go)</p>
 <h2 dir="auto">Code blocks</h2>
 <p dir="auto">This is a normal paragraph:</p>
-<pre><code>This is a code block.
+<pre class="notranslate"><code class="notranslate">This is a code block.
 </code></pre>
 <p dir="auto">Here is an example of AppleScript:</p>
-<pre><code>tell application "Foo"
+<pre class="notranslate"><code class="notranslate">tell application "Foo"
     beep
 end tell
 </code></pre>
 <p dir="auto">Markdown will handle the hassle of encoding the ampersands and angle brackets:</p>
-<pre><code>&lt;div class="footer"&gt;
+<pre class="notranslate"><code class="notranslate">&lt;div class="footer"&gt;
     &amp;copy; 2004 Foo Corporation
 &lt;/div&gt;
 
@@ -246,10 +246,10 @@ def this_is
   puts "some #{4-space-indent} code"
 end
 </code></pre>
-<code>
+<code class="notranslate">
 print('Code block')
 </code>
-<pre>print('Pre block')
+<pre class="notranslate">print('Pre block')
 </pre>
 <h2 dir="auto">Horizontal rules</h2>
 <hr>
@@ -283,19 +283,19 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 </ul>
 <h2 dir="auto">Code</h2>
 <ul dir="auto">
-<li>Use the <code>printf()</code> function.</li>
-<li><code>There is a literal backtick (`) here.</code></li>
-<li>A single backtick in a code span: <code>`</code></li>
-<li>A backtick-delimited string in a code span: <code>`foo`</code></li>
-<li>Please don't use any <code>&lt;blink&gt;</code> tags.</li>
-<li><code>&amp;#8212;</code> is the decimal-encoded equivalent of <code>&amp;mdash;</code></li>
+<li>Use the <code class="notranslate">printf()</code> function.</li>
+<li><code class="notranslate">There is a literal backtick (`) here.</code></li>
+<li>A single backtick in a code span: <code class="notranslate">`</code></li>
+<li>A backtick-delimited string in a code span: <code class="notranslate">`foo`</code></li>
+<li>Please don't use any <code class="notranslate">&lt;blink&gt;</code> tags.</li>
+<li><code class="notranslate">&amp;#8212;</code> is the decimal-encoded equivalent of <code class="notranslate">&amp;mdash;</code></li>
 </ul>
 <h2 dir="auto">Images</h2>
 <ul dir="auto">
-<li><a target="_blank" rel="noopener noreferrer" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" style="max-width: 100%;"></a></li>
-<li><a target="_blank" rel="noopener noreferrer" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" title="Optional title" style="max-width: 100%;"></a></li>
-<li><a target="_blank" rel="noopener noreferrer" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" title="Optional title attribute" style="max-width: 100%;"></a></li>
-<li><a target="_blank" rel="noopener noreferrer" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" width="32" height="32" style="max-width: 100%;"></a>   ← bigger &amp; blurrier</li>
+<li><a target="_blank" rel="noopener noreferrer nofollow" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" style="max-width: 100%;"></a></li>
+<li><a target="_blank" rel="noopener noreferrer nofollow" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" title="Optional title" style="max-width: 100%;"></a></li>
+<li><a target="_blank" rel="noopener noreferrer nofollow" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" title="Optional title attribute" style="max-width: 100%;"></a></li>
+<li><a target="_blank" rel="noopener noreferrer nofollow" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" width="32" height="32" style="max-width: 100%; height: auto; max-height: 32px;"></a>   ← bigger &amp; blurrier</li>
 </ul>
 <h2 dir="auto">Automatic links</h2>
 <ul dir="auto">
@@ -329,19 +329,19 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <h4 dir="auto">Strikethrough</h4>
 <p dir="auto"><del>Mistaken text.</del></p>
 <h4 dir="auto">Fenced code blocks</h4>
-<pre><code>function test() {
+<pre class="notranslate"><code class="notranslate">function test() {
   console.log("notice the blank line before this function?");
 }
 </code></pre>
 <h4 dir="auto">Syntax highlighting</h4>
-<div class="highlight highlight-source-python"><pre><span class="pl-en">print</span>(<span class="pl-s">'Hello!'</span>)</pre></div>
-<div class="highlight highlight-source-js"><pre><span class="pl-smi">console</span><span class="pl-kos">.</span><span class="pl-en">log</span><span class="pl-kos">(</span><span class="pl-s">'JavaScript!'</span><span class="pl-kos">)</span><span class="pl-kos">;</span></pre></div>
-<div class="highlight highlight-source-js"><pre><span class="pl-smi">console</span><span class="pl-kos">.</span><span class="pl-en">log</span><span class="pl-kos">(</span><span class="pl-s">'JavaScript (with js)!'</span><span class="pl-kos">)</span><span class="pl-kos">;</span></pre></div>
-<pre lang="unmatched_language"><code>console.log('No matching language, but looks like JavaScript.');
+<div class="highlight highlight-source-python" dir="auto"><pre class="notranslate"><span class="pl-en">print</span>(<span class="pl-s">'Hello!'</span>)</pre></div>
+<div class="highlight highlight-source-js" dir="auto"><pre class="notranslate"><span class="pl-smi">console</span><span class="pl-kos">.</span><span class="pl-en">log</span><span class="pl-kos">(</span><span class="pl-s">'JavaScript!'</span><span class="pl-kos">)</span><span class="pl-kos">;</span></pre></div>
+<div class="highlight highlight-source-js" dir="auto"><pre class="notranslate"><span class="pl-smi">console</span><span class="pl-kos">.</span><span class="pl-en">log</span><span class="pl-kos">(</span><span class="pl-s">'JavaScript (with js)!'</span><span class="pl-kos">)</span><span class="pl-kos">;</span></pre></div>
+<pre lang="unmatched_language" class="notranslate"><code class="notranslate">console.log('No matching language, but looks like JavaScript.');
 </code></pre>
 <h4 dir="auto">Tables</h4>
 <p dir="auto">Simple:</p>
-<table role="table">
+<markdown-accessiblity-table><table role="table">
 <thead>
 <tr>
 <th>First Header</th>
@@ -358,9 +358,9 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <td>Content Cell</td>
 </tr>
 </tbody>
-</table>
+</table></markdown-accessiblity-table>
 <p dir="auto">Pipes:</p>
-<table role="table">
+<markdown-accessiblity-table><table role="table">
 <thead>
 <tr>
 <th>First Header</th>
@@ -377,9 +377,9 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <td>Content Cell</td>
 </tr>
 </tbody>
-</table>
+</table></markdown-accessiblity-table>
 <p dir="auto">Unmatched:</p>
-<table role="table">
+<markdown-accessiblity-table><table role="table">
 <thead>
 <tr>
 <th>Name</th>
@@ -396,9 +396,9 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <td>Closes a window</td>
 </tr>
 </tbody>
-</table>
+</table></markdown-accessiblity-table>
 <p dir="auto">Inner Markdown:</p>
-<table role="table">
+<markdown-accessiblity-table><table role="table">
 <thead>
 <tr>
 <th>Name</th>
@@ -415,9 +415,9 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <td><em>Closes</em> a window</td>
 </tr>
 </tbody>
-</table>
+</table></markdown-accessiblity-table>
 <p dir="auto">Alignment:</p>
-<table role="table">
+<markdown-accessiblity-table><table role="table">
 <thead>
 <tr>
 <th align="left">Left-Aligned</th>
@@ -447,7 +447,7 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <td align="right"></td>
 </tr>
 </tbody>
-</table>
+</table></markdown-accessiblity-table>
 <h4 dir="auto">HTML</h4>
 <p dir="auto"><em>TODO: Test all allowed HTML tags.</em></p>
 <h2 dir="auto">Writing on GitHub</h2>
@@ -457,21 +457,21 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 Violets are Blue</p>
 <h4 dir="auto">Task lists</h4>
 <ul class="contains-task-list">
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" checked=""> @mentions, #refs, <a href="">links</a>, <strong>formatting</strong>, and <del>tags</del> are supported</li>
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" checked=""> list syntax is required (any unordered or ordered list supported)</li>
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" checked=""> this is a complete item</li>
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox"> this is an incomplete item</li>
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Completed task" checked=""> @mentions, #refs, <a href="">links</a>, <strong>formatting</strong>, and <del>tags</del> are supported</li>
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Completed task" checked=""> list syntax is required (any unordered or ordered list supported)</li>
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Completed task" checked=""> this is a complete item</li>
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Incomplete task"> this is an incomplete item</li>
 </ul>
 <p dir="auto">Task lists can be nested to better structure your tasks:</p>
 <ul class="contains-task-list">
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox"> a bigger project
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Incomplete task"> a bigger project
 <ul class="contains-task-list">
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" checked=""> first subtask #1234</li>
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox"> follow up subtask #4321</li>
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox"> final subtask cc @mention</li>
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Completed task" checked=""> first subtask #1234</li>
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Incomplete task"> follow up subtask #4321</li>
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Incomplete task"> final subtask cc @mention</li>
 </ul>
 </li>
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" checked=""> a separate task</li>
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Completed task" checked=""> a separate task</li>
 </ul>
 <h4 dir="auto">References</h4>
 <ul dir="auto">

--- a/tests/output/raw/gfm-test.html
+++ b/tests/output/raw/gfm-test.html
@@ -1,14 +1,12 @@
-<h1>
-<a id="user-content-github-flavored-markdown-test" class="anchor" href="#github-flavored-markdown-test" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>GitHub Flavored Markdown Test</h1>
+<div class="markdown-heading"><h1 class="heading-element">GitHub Flavored Markdown Test</h1><a id="user-content-github-flavored-markdown-test" class="anchor" aria-label="Permalink: GitHub Flavored Markdown Test" href="#github-flavored-markdown-test"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>This Markdown file contains all the features of <strong>GitHub Flavored Markdown</strong> for
 testing a renderer with.</p>
 <p>The features are taken directly from <a href="https://daringfireball.net/projects/markdown/syntax" rel="nofollow">Daring Fireball</a>
 and <a href="https://help.github.com/articles/github-flavored-markdown/">GitHub Flavored Markdown</a>,
 followed by a list of one-offs.</p>
-<h2>
-<a id="user-content-inline-html" class="anchor" href="#inline-html" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Inline HTML</h2>
+<div class="markdown-heading"><h2 class="heading-element">Inline HTML</h2><a id="user-content-inline-html" class="anchor" aria-label="Permalink: Inline HTML" href="#inline-html"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <table>
-  <tr>
+  <tbody><tr>
     <td>Foo</td>
   </tr>
   <tr>
@@ -17,13 +15,12 @@ followed by a list of one-offs.</p>
       E.g., you can’t use Markdown-style *emphasis* inside an HTML block.
     </td>
   </tr>
-</table>
+</tbody></table>
 <p>Span-level HTML tags — e.g. &lt;span&gt;, &lt;cite&gt;, or &lt;del&gt; — can be used anywhere
 in a Markdown paragraph, list item, or header. If you want, you can even use HTML tags instead
 of Markdown formatting; e.g. if you’d prefer to use HTML &lt;a&gt; or &lt;img&gt; tags instead
 of Markdown’s link or image syntax, go right ahead.</p>
-<h4>
-<a id="user-content-testing-span-cite-and-del-tags" class="anchor" href="#testing-span-cite-and-del-tags" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Testing <span>span</span>, cite, and <del>del</del> tags</h4>
+<div class="markdown-heading"><h4 class="heading-element">Testing <span>span</span>, cite, and <del>del</del> tags</h4><a id="user-content-testing-span-cite-and-del-tags" class="anchor" aria-label="Permalink: Testing span, cite, and del tags" href="#testing-span-cite-and-del-tags"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Testing <span>span</span>, cite, and <del>del</del> tags in a paragraph.</p>
 <p>And each element in its own list item:</p>
 <ul>
@@ -31,8 +28,7 @@ of Markdown’s link or image syntax, go right ahead.</p>
 <li>This is within a cite tag.</li>
 <li><del>This is within a del tag.</del></li>
 </ul>
-<h2>
-<a id="user-content-automatic-escaping-for-special-characters" class="anchor" href="#automatic-escaping-for-special-characters" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Automatic escaping for special characters</h2>
+<div class="markdown-heading"><h2 class="heading-element">Automatic escaping for special characters</h2><a id="user-content-automatic-escaping-for-special-characters" class="anchor" aria-label="Permalink: Automatic escaping for special characters" href="#automatic-escaping-for-special-characters"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ul>
 <li>© copyright</li>
 <li>AT&amp;T should render the same as AT&amp;T</li>
@@ -44,8 +40,7 @@ convert <code>&amp;amp;</code>. So these two should yield different links:</p>
 <li><a href="http://images.google.com/images?num=30&amp;q=larry+bird" rel="nofollow">http://images.google.com/images?num=30&amp;q=larry+bird</a></li>
 <li><a href="http://images.google.com/images?num=30&amp;amp;q=larry+bird" rel="nofollow">http://images.google.com/images?num=30&amp;amp;q=larry+bird</a></li>
 </ul>
-<h2>
-<a id="user-content-paragraphs-and-line-breaks" class="anchor" href="#paragraphs-and-line-breaks" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Paragraphs and line breaks</h2>
+<div class="markdown-heading"><h2 class="heading-element">Paragraphs and line breaks</h2><a id="user-content-paragraphs-and-line-breaks" class="anchor" aria-label="Permalink: Paragraphs and line breaks" href="#paragraphs-and-line-breaks"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>This is a normal paragraph.</p>
 <p>This and the next sentence is separated by a single newline.
 This should be on the same line.</p>
@@ -55,36 +50,26 @@ This should be on a new line, directly below.</p>
 This should be two lines below.</p>
 <p>These two paragraphs are separated by two <code>&lt;br /&gt;</code> tags. <br><br></p>
 <p>This should be three lines below.</p>
-<h2>
-<a id="user-content-headers" class="anchor" href="#headers" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Headers</h2>
+<div class="markdown-heading"><h2 class="heading-element">Headers</h2><a id="user-content-headers" class="anchor" aria-label="Permalink: Headers" href="#headers"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Here are some headers followed by <a href="https://en.wikipedia.org/wiki/Lorem_ipsum" rel="nofollow">Lorem Ipsum</a>.</p>
-<h1>
-<a id="user-content-this-is-an-h1-setext-style" class="anchor" href="#this-is-an-h1-setext-style" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>This is an H1 (Setext-style)</h1>
+<div class="markdown-heading"><h1 class="heading-element">This is an H1 (Setext-style)</h1><a id="user-content-this-is-an-h1-setext-style" class="anchor" aria-label="Permalink: This is an H1 (Setext-style)" href="#this-is-an-h1-setext-style"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-<h2>
-<a id="user-content-this-is-an-h2-setext-style" class="anchor" href="#this-is-an-h2-setext-style" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>This is an H2 (Setext-style)</h2>
+<div class="markdown-heading"><h2 class="heading-element">This is an H2 (Setext-style)</h2><a id="user-content-this-is-an-h2-setext-style" class="anchor" aria-label="Permalink: This is an H2 (Setext-style)" href="#this-is-an-h2-setext-style"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 <p>The following are atx-style.</p>
-<h1>
-<a id="user-content-this-is-an-h1" class="anchor" href="#this-is-an-h1" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>This is an H1</h1>
+<div class="markdown-heading"><h1 class="heading-element">This is an H1</h1><a id="user-content-this-is-an-h1" class="anchor" aria-label="Permalink: This is an H1" href="#this-is-an-h1"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-<h2>
-<a id="user-content-this-is-an-h2" class="anchor" href="#this-is-an-h2" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>This is an H2</h2>
+<div class="markdown-heading"><h2 class="heading-element">This is an H2</h2><a id="user-content-this-is-an-h2" class="anchor" aria-label="Permalink: This is an H2" href="#this-is-an-h2"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Mauris feugiat, augue vitae sollicitudin vulputate, neque arcu dapibus eros, eget semper lorem ex rhoncus nulla.</p>
-<h3>
-<a id="user-content-this-is-an-h3" class="anchor" href="#this-is-an-h3" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>This is an H3</h3>
+<div class="markdown-heading"><h3 class="heading-element">This is an H3</h3><a id="user-content-this-is-an-h3" class="anchor" aria-label="Permalink: This is an H3" href="#this-is-an-h3"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Etiam sit amet orci sit amet dui mollis molestie.</p>
-<h4>
-<a id="user-content-this-is-an-h4" class="anchor" href="#this-is-an-h4" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>This is an H4</h4>
+<div class="markdown-heading"><h4 class="heading-element">This is an H4</h4><a id="user-content-this-is-an-h4" class="anchor" aria-label="Permalink: This is an H4" href="#this-is-an-h4"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Cras et elit egestas, lacinia est eu, vestibulum enim.</p>
-<h5>
-<a id="user-content-this-is-an-h5" class="anchor" href="#this-is-an-h5" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>This is an H5</h5>
+<div class="markdown-heading"><h5 class="heading-element">This is an H5</h5><a id="user-content-this-is-an-h5" class="anchor" aria-label="Permalink: This is an H5" href="#this-is-an-h5"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Phasellus sed suscipit quam.</p>
-<h6>
-<a id="user-content-this-is-an-h36" class="anchor" href="#this-is-an-h36" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>This is an H√36</h6>
+<div class="markdown-heading"><h6 class="heading-element">This is an H√36</h6><a id="user-content-this-is-an-h36" class="anchor" aria-label="Permalink: This is an H√36" href="#this-is-an-h36"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Nam rutrum imperdiet purus, sit amet porttitor augue tempor quis.</p>
-<h2>
-<a id="user-content-blockquotes" class="anchor" href="#blockquotes" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Blockquotes</h2>
+<div class="markdown-heading"><h2 class="heading-element">Blockquotes</h2><a id="user-content-blockquotes" class="anchor" aria-label="Permalink: Blockquotes" href="#blockquotes"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Email-style blockquotes:</p>
 <blockquote>
 <p>This is a blockquote with two paragraphs. Lorem ipsum dolor sit amet,
@@ -113,8 +98,7 @@ id sem consectetuer libero luctus adipiscing.</p>
 </blockquote>
 <p>Blockquotes containing other Markdown elements:</p>
 <blockquote>
-<h2>
-<a id="user-content-this-is-a-header" class="anchor" href="#this-is-a-header" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>This is a header.</h2>
+<div class="markdown-heading"><h2 class="heading-element">This is a header.</h2><a id="user-content-this-is-a-header" class="anchor" aria-label="Permalink: This is a header." href="#this-is-a-header"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ol>
 <li>This is the first list item.</li>
 <li>This is the second list item.</li>
@@ -123,10 +107,8 @@ id sem consectetuer libero luctus adipiscing.</p>
 <pre><code>return shell_exec("echo $input | $markdown_script");
 </code></pre>
 </blockquote>
-<h2>
-<a id="user-content-lists" class="anchor" href="#lists" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Lists</h2>
-<h5>
-<a id="user-content-these-three-lists-should-be-equivalent" class="anchor" href="#these-three-lists-should-be-equivalent" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>These three lists should be equivalent</h5>
+<div class="markdown-heading"><h2 class="heading-element">Lists</h2><a id="user-content-lists" class="anchor" aria-label="Permalink: Lists" href="#lists"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
+<div class="markdown-heading"><h5 class="heading-element">These three lists should be equivalent</h5><a id="user-content-these-three-lists-should-be-equivalent" class="anchor" aria-label="Permalink: These three lists should be equivalent" href="#these-three-lists-should-be-equivalent"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>First:</p>
 <ul>
 <li>Red</li>
@@ -145,8 +127,7 @@ id sem consectetuer libero luctus adipiscing.</p>
 <li>Green</li>
 <li>Blue</li>
 </ul>
-<h4>
-<a id="user-content-these-three-ordered-lists-should-be-equivalent" class="anchor" href="#these-three-ordered-lists-should-be-equivalent" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>These three ordered lists should be equivalent</h4>
+<div class="markdown-heading"><h4 class="heading-element">These three ordered lists should be equivalent</h4><a id="user-content-these-three-ordered-lists-should-be-equivalent" class="anchor" aria-label="Permalink: These three ordered lists should be equivalent" href="#these-three-ordered-lists-should-be-equivalent"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>First:</p>
 <ol>
 <li>Bird</li>
@@ -165,8 +146,7 @@ id sem consectetuer libero luctus adipiscing.</p>
 <li>McHale</li>
 <li>Parish</li>
 </ol>
-<h4>
-<a id="user-content-these-two-lists-should-be-equivalent" class="anchor" href="#these-two-lists-should-be-equivalent" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>These two lists should be equivalent</h4>
+<div class="markdown-heading"><h4 class="heading-element">These two lists should be equivalent</h4><a id="user-content-these-two-lists-should-be-equivalent" class="anchor" aria-label="Permalink: These two lists should be equivalent" href="#these-two-lists-should-be-equivalent"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>First:</p>
 <ul>
 <li>Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
@@ -183,8 +163,7 @@ viverra nec, fringilla in, laoreet vitae, risus.</li>
 <li>Donec sit amet nisl. Aliquam semper ipsum sit amet velit.
 Suspendisse id sem consectetuer libero luctus adipiscing.</li>
 </ul>
-<h4>
-<a id="user-content-paragraphs-and-lists" class="anchor" href="#paragraphs-and-lists" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Paragraphs and lists</h4>
+<div class="markdown-heading"><h4 class="heading-element">Paragraphs and lists</h4><a id="user-content-paragraphs-and-lists" class="anchor" aria-label="Permalink: Paragraphs and lists" href="#paragraphs-and-lists"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ul>
 <li>Bird</li>
 <li>Magic</li>
@@ -198,8 +177,7 @@ Suspendisse id sem consectetuer libero luctus adipiscing.</li>
 <p>Magic</p>
 </li>
 </ul>
-<h4>
-<a id="user-content-paragraphs-within-lists" class="anchor" href="#paragraphs-within-lists" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Paragraphs within lists</h4>
+<div class="markdown-heading"><h4 class="heading-element">Paragraphs within lists</h4><a id="user-content-paragraphs-within-lists" class="anchor" aria-label="Permalink: Paragraphs within lists" href="#paragraphs-within-lists"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>First:</p>
 <ol>
 <li>
@@ -226,8 +204,7 @@ sit amet, consectetuer adipiscing elit.</p>
 <p>Another item in the same list.</p>
 </li>
 </ul>
-<h4>
-<a id="user-content-blockquote-within-a-list" class="anchor" href="#blockquote-within-a-list" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Blockquote within a list</h4>
+<div class="markdown-heading"><h4 class="heading-element">Blockquote within a list</h4><a id="user-content-blockquote-within-a-list" class="anchor" aria-label="Permalink: Blockquote within a list" href="#blockquote-within-a-list"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ul>
 <li>
 <p>A list item with a blockquote:</p>
@@ -237,8 +214,7 @@ inside a list item.</p>
 </blockquote>
 </li>
 </ul>
-<h4>
-<a id="user-content-code-within-a-list" class="anchor" href="#code-within-a-list" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Code within a list</h4>
+<div class="markdown-heading"><h4 class="heading-element">Code within a list</h4><a id="user-content-code-within-a-list" class="anchor" aria-label="Permalink: Code within a list" href="#code-within-a-list"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ul>
 <li>
 <p>A list item with a code block:</p>
@@ -246,14 +222,12 @@ inside a list item.</p>
 </code></pre>
 </li>
 </ul>
-<h4>
-<a id="user-content-accidental-lists" class="anchor" href="#accidental-lists" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Accidental lists</h4>
+<div class="markdown-heading"><h4 class="heading-element">Accidental lists</h4><a id="user-content-accidental-lists" class="anchor" aria-label="Permalink: Accidental lists" href="#accidental-lists"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ol start="1986">
 <li>What a great season. (oops, I wanted a year, not a list)</li>
 </ol>
 <p>1986. What a great season. (<em>whew!</em> there we go)</p>
-<h2>
-<a id="user-content-code-blocks" class="anchor" href="#code-blocks" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Code blocks</h2>
+<div class="markdown-heading"><h2 class="heading-element">Code blocks</h2><a id="user-content-code-blocks" class="anchor" aria-label="Permalink: Code blocks" href="#code-blocks"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>This is a normal paragraph:</p>
 <pre><code>This is a code block.
 </code></pre>
@@ -275,18 +249,15 @@ end
 <code>
 print('Code block')
 </code>
-<pre>
-print('Pre block')
+<pre>print('Pre block')
 </pre>
-<h2>
-<a id="user-content-horizontal-rules" class="anchor" href="#horizontal-rules" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Horizontal rules</h2>
+<div class="markdown-heading"><h2 class="heading-element">Horizontal rules</h2><a id="user-content-horizontal-rules" class="anchor" aria-label="Permalink: Horizontal rules" href="#horizontal-rules"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <hr>
 <hr>
 <hr>
 <hr>
 <hr>
-<h2>
-<a id="user-content-links" class="anchor" href="#links" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Links</h2>
+<div class="markdown-heading"><h2 class="heading-element">Links</h2><a id="user-content-links" class="anchor" aria-label="Permalink: Links" href="#links"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Markdown supports two style of links: inline and reference.</p>
 <p>This is <a href="http://joeyespo.com/" title="Title" rel="nofollow">an example</a> inline link.</p>
 <p><a href="http://joeyespo.com/" rel="nofollow">This link</a> has no title attribute.</p>
@@ -301,8 +272,7 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <li><a href="http://joeyespo.com/" title="Optional Title Here" rel="nofollow">foo 4</a></li>
 <li><a href="http://joeyespo.com/" title="Optional Title Here" rel="nofollow">foo 5</a></li>
 </ul>
-<h2>
-<a id="user-content-emphasis" class="anchor" href="#emphasis" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Emphasis</h2>
+<div class="markdown-heading"><h2 class="heading-element">Emphasis</h2><a id="user-content-emphasis" class="anchor" aria-label="Permalink: Emphasis" href="#emphasis"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ul>
 <li><em>single asterisks</em></li>
 <li><em>single underscores</em></li>
@@ -311,8 +281,7 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <li>un<em>frigging</em>believable</li>
 <li>*this text is surrounded by literal asterisks*</li>
 </ul>
-<h2>
-<a id="user-content-code" class="anchor" href="#code" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Code</h2>
+<div class="markdown-heading"><h2 class="heading-element">Code</h2><a id="user-content-code" class="anchor" aria-label="Permalink: Code" href="#code"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ul>
 <li>Use the <code>printf()</code> function.</li>
 <li><code>There is a literal backtick (`) here.</code></li>
@@ -325,23 +294,20 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <code>&amp;#8212;</code> is the decimal-encoded equivalent of <code>&amp;mdash;</code>
 </li>
 </ul>
-<h2>
-<a id="user-content-images" class="anchor" href="#images" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Images</h2>
+<div class="markdown-heading"><h2 class="heading-element">Images</h2><a id="user-content-images" class="anchor" aria-label="Permalink: Images" href="#images"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ul>
-<li><a href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" target="_blank" rel="nofollow"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" style="max-width:100%;"></a></li>
-<li><a href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" target="_blank" rel="nofollow"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" title="Optional title" style="max-width:100%;"></a></li>
-<li><a href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" target="_blank" rel="nofollow"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" title="Optional title attribute" style="max-width:100%;"></a></li>
+<li><a target="_blank" rel="noopener noreferrer nofollow" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" style="max-width: 100%;"></a></li>
+<li><a target="_blank" rel="noopener noreferrer nofollow" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" title="Optional title" style="max-width: 100%;"></a></li>
+<li><a target="_blank" rel="noopener noreferrer nofollow" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" title="Optional title attribute" style="max-width: 100%;"></a></li>
 <li>
-<a href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" target="_blank" rel="nofollow"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" width="32" height="32" style="max-width:100%;"></a>   ← bigger &amp; blurrier</li>
+<a target="_blank" rel="noopener noreferrer nofollow" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" width="32" height="32" style="max-width: 100%; height: auto; max-height: 32px;"></a>   ← bigger &amp; blurrier</li>
 </ul>
-<h2>
-<a id="user-content-automatic-links" class="anchor" href="#automatic-links" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Automatic links</h2>
+<div class="markdown-heading"><h2 class="heading-element">Automatic links</h2><a id="user-content-automatic-links" class="anchor" aria-label="Permalink: Automatic links" href="#automatic-links"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ul>
 <li><a href="http://joeyespo.com/" rel="nofollow">http://joeyespo.com/</a></li>
 <li><a href="mailto:joe@joeyespo.com">joe@joeyespo.com</a></li>
 </ul>
-<h2>
-<a id="user-content-backslash-escapes" class="anchor" href="#backslash-escapes" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Backslash escapes</h2>
+<div class="markdown-heading"><h2 class="heading-element">Backslash escapes</h2><a id="user-content-backslash-escapes" class="anchor" aria-label="Permalink: Backslash escapes" href="#backslash-escapes"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ul>
 <li>*literal asterisks*</li>
 <li>\   backslash</li>
@@ -357,35 +323,28 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <li>.   dot</li>
 <li>!   exclamation mark</li>
 </ul>
-<h2>
-<a id="user-content-github-flavored-markdown" class="anchor" href="#github-flavored-markdown" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>GitHub Flavored Markdown</h2>
+<div class="markdown-heading"><h2 class="heading-element">GitHub Flavored Markdown</h2><a id="user-content-github-flavored-markdown" class="anchor" aria-label="Permalink: GitHub Flavored Markdown" href="#github-flavored-markdown"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>See <a href="https://help.github.com/articles/github-flavored-markdown/">GitHub Flavored Markdown</a> for details.</p>
-<h4>
-<a id="user-content-multiple-underscores-in-words" class="anchor" href="#multiple-underscores-in-words" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Multiple underscores in words</h4>
+<div class="markdown-heading"><h4 class="heading-element">Multiple underscores in words</h4><a id="user-content-multiple-underscores-in-words" class="anchor" aria-label="Permalink: Multiple underscores in words" href="#multiple-underscores-in-words"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ul>
 <li>wow_great_stuff</li>
 </ul>
-<h4>
-<a id="user-content-url-autolinking" class="anchor" href="#url-autolinking" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>URL autolinking</h4>
+<div class="markdown-heading"><h4 class="heading-element">URL autolinking</h4><a id="user-content-url-autolinking" class="anchor" aria-label="Permalink: URL autolinking" href="#url-autolinking"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p><a href="http://joeyespo.com" rel="nofollow">http://joeyespo.com</a></p>
-<h4>
-<a id="user-content-strikethrough" class="anchor" href="#strikethrough" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Strikethrough</h4>
+<div class="markdown-heading"><h4 class="heading-element">Strikethrough</h4><a id="user-content-strikethrough" class="anchor" aria-label="Permalink: Strikethrough" href="#strikethrough"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p><del>Mistaken text.</del></p>
-<h4>
-<a id="user-content-fenced-code-blocks" class="anchor" href="#fenced-code-blocks" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Fenced code blocks</h4>
+<div class="markdown-heading"><h4 class="heading-element">Fenced code blocks</h4><a id="user-content-fenced-code-blocks" class="anchor" aria-label="Permalink: Fenced code blocks" href="#fenced-code-blocks"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <pre><code>function test() {
   console.log("notice the blank line before this function?");
 }
 </code></pre>
-<h4>
-<a id="user-content-syntax-highlighting" class="anchor" href="#syntax-highlighting" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Syntax highlighting</h4>
+<div class="markdown-heading"><h4 class="heading-element">Syntax highlighting</h4><a id="user-content-syntax-highlighting" class="anchor" aria-label="Permalink: Syntax highlighting" href="#syntax-highlighting"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <div class="highlight highlight-source-python"><pre><span class="pl-en">print</span>(<span class="pl-s">'Hello!'</span>)</pre></div>
 <div class="highlight highlight-source-js"><pre><span class="pl-smi">console</span><span class="pl-kos">.</span><span class="pl-en">log</span><span class="pl-kos">(</span><span class="pl-s">'JavaScript!'</span><span class="pl-kos">)</span><span class="pl-kos">;</span></pre></div>
 <div class="highlight highlight-source-js"><pre><span class="pl-smi">console</span><span class="pl-kos">.</span><span class="pl-en">log</span><span class="pl-kos">(</span><span class="pl-s">'JavaScript (with js)!'</span><span class="pl-kos">)</span><span class="pl-kos">;</span></pre></div>
 <pre lang="unmatched_language"><code>console.log('No matching language, but looks like JavaScript.');
 </code></pre>
-<h4>
-<a id="user-content-tables" class="anchor" href="#tables" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Tables</h4>
+<div class="markdown-heading"><h4 class="heading-element">Tables</h4><a id="user-content-tables" class="anchor" aria-label="Permalink: Tables" href="#tables"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Simple:</p>
 <table>
 <thead>
@@ -496,18 +455,14 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 </tr>
 </tbody>
 </table>
-<h4>
-<a id="user-content-html" class="anchor" href="#html" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>HTML</h4>
+<div class="markdown-heading"><h4 class="heading-element">HTML</h4><a id="user-content-html" class="anchor" aria-label="Permalink: HTML" href="#html"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p><em>TODO: Test all allowed HTML tags.</em></p>
-<h2>
-<a id="user-content-writing-on-github" class="anchor" href="#writing-on-github" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Writing on GitHub</h2>
+<div class="markdown-heading"><h2 class="heading-element">Writing on GitHub</h2><a id="user-content-writing-on-github" class="anchor" aria-label="Permalink: Writing on GitHub" href="#writing-on-github"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>See <a href="https://help.github.com/articles/writing-on-github/">this article</a> for details.</p>
-<h4>
-<a id="user-content-newlines" class="anchor" href="#newlines" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Newlines</h4>
+<div class="markdown-heading"><h4 class="heading-element">Newlines</h4><a id="user-content-newlines" class="anchor" aria-label="Permalink: Newlines" href="#newlines"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Roses are red
 Violets are Blue</p>
-<h4>
-<a id="user-content-task-lists" class="anchor" href="#task-lists" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Task lists</h4>
+<div class="markdown-heading"><h4 class="heading-element">Task lists</h4><a id="user-content-task-lists" class="anchor" aria-label="Permalink: Task lists" href="#task-lists"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ul>
 <li>[x] @mentions, #refs, <a href="">links</a>, <strong>formatting</strong>, and <del>tags</del> are supported</li>
 <li>[x] list syntax is required (any unordered or ordered list supported)</li>
@@ -525,8 +480,7 @@ Violets are Blue</p>
 </li>
 <li>[x] a separate task</li>
 </ul>
-<h4>
-<a id="user-content-references" class="anchor" href="#references" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>References</h4>
+<div class="markdown-heading"><h4 class="heading-element">References</h4><a id="user-content-references" class="anchor" aria-label="Permalink: References" href="#references"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ul>
 <li>SHA: dbcd7a410ee7489acf92f40641a135fbcf52a768</li>
 <li>User@SHA: joeyespo@dbcd7a410ee7489acf92f40641a135fbcf52a768</li>

--- a/tests/output/raw/simple.html
+++ b/tests/output/raw/simple.html
@@ -1,3 +1,2 @@
-<h1>
-<a id="user-content-simple-test-" class="anchor" href="#simple-test-" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Simple Test ✓</h1>
+<div class="markdown-heading"><h1 class="heading-element">Simple Test ✓</h1><a id="user-content-simple-test-" class="anchor" aria-label="Permalink: Simple Test ✓" href="#simple-test-"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>This is just a simple Unicode Markdown test.</p>

--- a/tests/output/renderer/gfm-test-user-content.html
+++ b/tests/output/renderer/gfm-test-user-content.html
@@ -5,7 +5,7 @@ testing a renderer with.</p>
 and <a href="https://help.github.com/articles/github-flavored-markdown/">GitHub Flavored Markdown</a>,<br>
 followed by a list of one-offs.</p>
 <h2>Inline HTML</h2>
-<table role="table">
+<markdown-accessiblity-table><table role="table">
   <tbody><tr>
     <td>Foo</td>
   </tr>
@@ -15,7 +15,7 @@ followed by a list of one-offs.</p>
       E.g., you can’t use Markdown-style *emphasis* inside an HTML block.
     </td>
   </tr>
-</tbody></table>
+</tbody></table></markdown-accessiblity-table>
 <p>Span-level HTML tags — e.g. &lt;span&gt;, &lt;cite&gt;, or &lt;del&gt; — can be used anywhere<br>
 in a Markdown paragraph, list item, or header. If you want, you can even use HTML tags instead<br>
 of Markdown formatting; e.g. if you’d prefer to use HTML &lt;a&gt; or &lt;img&gt; tags instead<br>
@@ -35,7 +35,7 @@ of Markdown’s link or image syntax, go right ahead.</p>
 <li>4 &lt; 5 should render the same as 4 &lt; 5</li>
 </ul>
 <p>Note that GitHub Flavored Markdown has URL autolinking, which will <em>not</em><br>
-convert <code>&amp;amp;</code>. So these two should yield different links:</p>
+convert <code class="notranslate">&amp;amp;</code>. So these two should yield different links:</p>
 <ul>
 <li><a href="http://images.google.com/images?num=30&amp;q=larry+bird" rel="nofollow">http://images.google.com/images?num=30&amp;q=larry+bird</a></li>
 <li><a href="http://images.google.com/images?num=30&amp;amp;q=larry+bird" rel="nofollow">http://images.google.com/images?num=30&amp;amp;q=larry+bird</a></li>
@@ -44,11 +44,11 @@ convert <code>&amp;amp;</code>. So these two should yield different links:</p>
 <p>This is a normal paragraph.</p>
 <p>This and the next sentence is separated by a single newline.<br>
 This should be on the same line.</p>
-<p>This and the next sentence is joined by a single <code>&lt;br /&gt;</code>. <br><br>
+<p>This and the next sentence is joined by a single <code class="notranslate">&lt;br /&gt;</code>. <br><br>
 This should be on a new line, directly below.</p>
-<p>These two sentences are separated by two <code>&lt;br /&gt;</code> tags. <br><br><br>
+<p>These two sentences are separated by two <code class="notranslate">&lt;br /&gt;</code> tags. <br><br><br>
 This should be two lines below.</p>
-<p>These two paragraphs are separated by two <code>&lt;br /&gt;</code> tags. <br><br></p>
+<p>These two paragraphs are separated by two <code class="notranslate">&lt;br /&gt;</code> tags. <br><br></p>
 <p>This should be three lines below.</p>
 <h2>Headers</h2>
 <p>Here are some headers followed by <a href="https://en.wikipedia.org/wiki/Lorem_ipsum" rel="nofollow">Lorem Ipsum</a>.</p>
@@ -104,7 +104,7 @@ id sem consectetuer libero luctus adipiscing.</p>
 <li>This is the second list item.</li>
 </ol>
 <p>Here's some example code:</p>
-<pre><code>return shell_exec("echo $input | $markdown_script");
+<pre class="notranslate"><code class="notranslate">return shell_exec("echo $input | $markdown_script");
 </code></pre>
 </blockquote>
 <h2>Lists</h2>
@@ -218,7 +218,7 @@ inside a list item.</p>
 <ul>
 <li>
 <p>A list item with a code block:</p>
-<pre><code>&lt;code goes here&gt;
+<pre class="notranslate"><code class="notranslate">&lt;code goes here&gt;
 </code></pre>
 </li>
 </ul>
@@ -229,15 +229,15 @@ inside a list item.</p>
 <p>1986. What a great season. (<em>whew!</em> there we go)</p>
 <h2>Code blocks</h2>
 <p>This is a normal paragraph:</p>
-<pre><code>This is a code block.
+<pre class="notranslate"><code class="notranslate">This is a code block.
 </code></pre>
 <p>Here is an example of AppleScript:</p>
-<pre><code>tell application "Foo"
+<pre class="notranslate"><code class="notranslate">tell application "Foo"
     beep
 end tell
 </code></pre>
 <p>Markdown will handle the hassle of encoding the ampersands and angle brackets:</p>
-<pre><code>&lt;div class="footer"&gt;
+<pre class="notranslate"><code class="notranslate">&lt;div class="footer"&gt;
     &amp;copy; 2004 Foo Corporation
 &lt;/div&gt;
 
@@ -246,10 +246,10 @@ def this_is
   puts "some #{4-space-indent} code"
 end
 </code></pre>
-<code>
+<code class="notranslate">
 print('Code block')
 </code>
-<pre>print('Pre block')
+<pre class="notranslate">print('Pre block')
 </pre>
 <h2>Horizontal rules</h2>
 <hr>
@@ -283,19 +283,19 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 </ul>
 <h2>Code</h2>
 <ul>
-<li>Use the <code>printf()</code> function.</li>
-<li><code>There is a literal backtick (`) here.</code></li>
-<li>A single backtick in a code span: <code>`</code></li>
-<li>A backtick-delimited string in a code span: <code>`foo`</code></li>
-<li>Please don't use any <code>&lt;blink&gt;</code> tags.</li>
-<li><code>&amp;#8212;</code> is the decimal-encoded equivalent of <code>&amp;mdash;</code></li>
+<li>Use the <code class="notranslate">printf()</code> function.</li>
+<li><code class="notranslate">There is a literal backtick (`) here.</code></li>
+<li>A single backtick in a code span: <code class="notranslate">`</code></li>
+<li>A backtick-delimited string in a code span: <code class="notranslate">`foo`</code></li>
+<li>Please don't use any <code class="notranslate">&lt;blink&gt;</code> tags.</li>
+<li><code class="notranslate">&amp;#8212;</code> is the decimal-encoded equivalent of <code class="notranslate">&amp;mdash;</code></li>
 </ul>
 <h2>Images</h2>
 <ul>
-<li><a target="_blank" rel="noopener noreferrer" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" style="max-width: 100%;"></a></li>
-<li><a target="_blank" rel="noopener noreferrer" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" title="Optional title" style="max-width: 100%;"></a></li>
-<li><a target="_blank" rel="noopener noreferrer" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" title="Optional title attribute" style="max-width: 100%;"></a></li>
-<li><a target="_blank" rel="noopener noreferrer" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" width="32" height="32" style="max-width: 100%;"></a>   ← bigger &amp; blurrier</li>
+<li><a target="_blank" rel="noopener noreferrer nofollow" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" style="max-width: 100%;"></a></li>
+<li><a target="_blank" rel="noopener noreferrer nofollow" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" title="Optional title" style="max-width: 100%;"></a></li>
+<li><a target="_blank" rel="noopener noreferrer nofollow" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" title="Optional title attribute" style="max-width: 100%;"></a></li>
+<li><a target="_blank" rel="noopener noreferrer nofollow" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" width="32" height="32" style="max-width: 100%; height: auto; max-height: 32px;"></a>   ← bigger &amp; blurrier</li>
 </ul>
 <h2>Automatic links</h2>
 <ul>
@@ -329,19 +329,19 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <h4>Strikethrough</h4>
 <p><del>Mistaken text.</del></p>
 <h4>Fenced code blocks</h4>
-<pre><code>function test() {
+<pre class="notranslate"><code class="notranslate">function test() {
   console.log("notice the blank line before this function?");
 }
 </code></pre>
 <h4>Syntax highlighting</h4>
-<div class="highlight highlight-source-python"><pre><span class="pl-en">print</span>(<span class="pl-s">'Hello!'</span>)</pre></div>
-<div class="highlight highlight-source-js"><pre><span class="pl-smi">console</span><span class="pl-kos">.</span><span class="pl-en">log</span><span class="pl-kos">(</span><span class="pl-s">'JavaScript!'</span><span class="pl-kos">)</span><span class="pl-kos">;</span></pre></div>
-<div class="highlight highlight-source-js"><pre><span class="pl-smi">console</span><span class="pl-kos">.</span><span class="pl-en">log</span><span class="pl-kos">(</span><span class="pl-s">'JavaScript (with js)!'</span><span class="pl-kos">)</span><span class="pl-kos">;</span></pre></div>
-<pre lang="unmatched_language"><code>console.log('No matching language, but looks like JavaScript.');
+<div class="highlight highlight-source-python"><pre class="notranslate"><span class="pl-en">print</span>(<span class="pl-s">'Hello!'</span>)</pre></div>
+<div class="highlight highlight-source-js"><pre class="notranslate"><span class="pl-smi">console</span><span class="pl-kos">.</span><span class="pl-en">log</span><span class="pl-kos">(</span><span class="pl-s">'JavaScript!'</span><span class="pl-kos">)</span><span class="pl-kos">;</span></pre></div>
+<div class="highlight highlight-source-js"><pre class="notranslate"><span class="pl-smi">console</span><span class="pl-kos">.</span><span class="pl-en">log</span><span class="pl-kos">(</span><span class="pl-s">'JavaScript (with js)!'</span><span class="pl-kos">)</span><span class="pl-kos">;</span></pre></div>
+<pre lang="unmatched_language" class="notranslate"><code class="notranslate">console.log('No matching language, but looks like JavaScript.');
 </code></pre>
 <h4>Tables</h4>
 <p>Simple:</p>
-<table role="table">
+<markdown-accessiblity-table><table role="table">
 <thead>
 <tr>
 <th>First Header</th>
@@ -358,9 +358,9 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <td>Content Cell</td>
 </tr>
 </tbody>
-</table>
+</table></markdown-accessiblity-table>
 <p>Pipes:</p>
-<table role="table">
+<markdown-accessiblity-table><table role="table">
 <thead>
 <tr>
 <th>First Header</th>
@@ -377,9 +377,9 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <td>Content Cell</td>
 </tr>
 </tbody>
-</table>
+</table></markdown-accessiblity-table>
 <p>Unmatched:</p>
-<table role="table">
+<markdown-accessiblity-table><table role="table">
 <thead>
 <tr>
 <th>Name</th>
@@ -396,9 +396,9 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <td>Closes a window</td>
 </tr>
 </tbody>
-</table>
+</table></markdown-accessiblity-table>
 <p>Inner Markdown:</p>
-<table role="table">
+<markdown-accessiblity-table><table role="table">
 <thead>
 <tr>
 <th>Name</th>
@@ -415,9 +415,9 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <td><em>Closes</em> a window</td>
 </tr>
 </tbody>
-</table>
+</table></markdown-accessiblity-table>
 <p>Alignment:</p>
-<table role="table">
+<markdown-accessiblity-table><table role="table">
 <thead>
 <tr>
 <th align="left">Left-Aligned</th>
@@ -447,7 +447,7 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <td align="right"></td>
 </tr>
 </tbody>
-</table>
+</table></markdown-accessiblity-table>
 <h4>HTML</h4>
 <p><em>TODO: Test all allowed HTML tags.</em></p>
 <h2>Writing on GitHub</h2>
@@ -457,21 +457,21 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 Violets are Blue</p>
 <h4>Task lists</h4>
 <ul class="contains-task-list">
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" checked=""> @mentions, #refs, <a href="">links</a>, <strong>formatting</strong>, and <del>tags</del> are supported</li>
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" checked=""> list syntax is required (any unordered or ordered list supported)</li>
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" checked=""> this is a complete item</li>
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox"> this is an incomplete item</li>
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Completed task" checked=""> @mentions, #refs, <a href="">links</a>, <strong>formatting</strong>, and <del>tags</del> are supported</li>
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Completed task" checked=""> list syntax is required (any unordered or ordered list supported)</li>
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Completed task" checked=""> this is a complete item</li>
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Incomplete task"> this is an incomplete item</li>
 </ul>
 <p>Task lists can be nested to better structure your tasks:</p>
 <ul class="contains-task-list">
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox"> a bigger project
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Incomplete task"> a bigger project
 <ul class="contains-task-list">
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" checked=""> first subtask #1234</li>
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox"> follow up subtask #4321</li>
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox"> final subtask cc @mention</li>
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Completed task" checked=""> first subtask #1234</li>
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Incomplete task"> follow up subtask #4321</li>
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Incomplete task"> final subtask cc @mention</li>
 </ul>
 </li>
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" checked=""> a separate task</li>
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Completed task" checked=""> a separate task</li>
 </ul>
 <h4>References</h4>
 <ul>

--- a/tests/output/renderer/gfm-test-user-context.html
+++ b/tests/output/renderer/gfm-test-user-context.html
@@ -5,7 +5,7 @@ testing a renderer with.</p>
 and <a href="https://help.github.com/articles/github-flavored-markdown/">GitHub Flavored Markdown</a>,<br>
 followed by a list of one-offs.</p>
 <h2 dir="auto">Inline HTML</h2>
-<table role="table">
+<markdown-accessiblity-table><table role="table">
   <tbody><tr>
     <td>Foo</td>
   </tr>
@@ -15,7 +15,7 @@ followed by a list of one-offs.</p>
       E.g., you can’t use Markdown-style *emphasis* inside an HTML block.
     </td>
   </tr>
-</tbody></table>
+</tbody></table></markdown-accessiblity-table>
 <p dir="auto">Span-level HTML tags — e.g. &lt;span&gt;, &lt;cite&gt;, or &lt;del&gt; — can be used anywhere<br>
 in a Markdown paragraph, list item, or header. If you want, you can even use HTML tags instead<br>
 of Markdown formatting; e.g. if you’d prefer to use HTML &lt;a&gt; or &lt;img&gt; tags instead<br>
@@ -35,7 +35,7 @@ of Markdown’s link or image syntax, go right ahead.</p>
 <li>4 &lt; 5 should render the same as 4 &lt; 5</li>
 </ul>
 <p dir="auto">Note that GitHub Flavored Markdown has URL autolinking, which will <em>not</em><br>
-convert <code>&amp;amp;</code>. So these two should yield different links:</p>
+convert <code class="notranslate">&amp;amp;</code>. So these two should yield different links:</p>
 <ul dir="auto">
 <li><a href="http://images.google.com/images?num=30&amp;q=larry+bird" rel="nofollow">http://images.google.com/images?num=30&amp;q=larry+bird</a></li>
 <li><a href="http://images.google.com/images?num=30&amp;amp;q=larry+bird" rel="nofollow">http://images.google.com/images?num=30&amp;amp;q=larry+bird</a></li>
@@ -44,11 +44,11 @@ convert <code>&amp;amp;</code>. So these two should yield different links:</p>
 <p dir="auto">This is a normal paragraph.</p>
 <p dir="auto">This and the next sentence is separated by a single newline.<br>
 This should be on the same line.</p>
-<p dir="auto">This and the next sentence is joined by a single <code>&lt;br /&gt;</code>. <br><br>
+<p dir="auto">This and the next sentence is joined by a single <code class="notranslate">&lt;br /&gt;</code>. <br><br>
 This should be on a new line, directly below.</p>
-<p dir="auto">These two sentences are separated by two <code>&lt;br /&gt;</code> tags. <br><br><br>
+<p dir="auto">These two sentences are separated by two <code class="notranslate">&lt;br /&gt;</code> tags. <br><br><br>
 This should be two lines below.</p>
-<p dir="auto">These two paragraphs are separated by two <code>&lt;br /&gt;</code> tags. <br><br></p>
+<p dir="auto">These two paragraphs are separated by two <code class="notranslate">&lt;br /&gt;</code> tags. <br><br></p>
 <p dir="auto">This should be three lines below.</p>
 <h2 dir="auto">Headers</h2>
 <p dir="auto">Here are some headers followed by <a href="https://en.wikipedia.org/wiki/Lorem_ipsum" rel="nofollow">Lorem Ipsum</a>.</p>
@@ -104,7 +104,7 @@ id sem consectetuer libero luctus adipiscing.</p>
 <li>This is the second list item.</li>
 </ol>
 <p dir="auto">Here's some example code:</p>
-<pre><code>return shell_exec("echo $input | $markdown_script");
+<pre class="notranslate"><code class="notranslate">return shell_exec("echo $input | $markdown_script");
 </code></pre>
 </blockquote>
 <h2 dir="auto">Lists</h2>
@@ -218,7 +218,7 @@ inside a list item.</p>
 <ul dir="auto">
 <li>
 <p dir="auto">A list item with a code block:</p>
-<pre><code>&lt;code goes here&gt;
+<pre class="notranslate"><code class="notranslate">&lt;code goes here&gt;
 </code></pre>
 </li>
 </ul>
@@ -229,15 +229,15 @@ inside a list item.</p>
 <p dir="auto">1986. What a great season. (<em>whew!</em> there we go)</p>
 <h2 dir="auto">Code blocks</h2>
 <p dir="auto">This is a normal paragraph:</p>
-<pre><code>This is a code block.
+<pre class="notranslate"><code class="notranslate">This is a code block.
 </code></pre>
 <p dir="auto">Here is an example of AppleScript:</p>
-<pre><code>tell application "Foo"
+<pre class="notranslate"><code class="notranslate">tell application "Foo"
     beep
 end tell
 </code></pre>
 <p dir="auto">Markdown will handle the hassle of encoding the ampersands and angle brackets:</p>
-<pre><code>&lt;div class="footer"&gt;
+<pre class="notranslate"><code class="notranslate">&lt;div class="footer"&gt;
     &amp;copy; 2004 Foo Corporation
 &lt;/div&gt;
 
@@ -246,10 +246,10 @@ def this_is
   puts "some #{4-space-indent} code"
 end
 </code></pre>
-<code>
+<code class="notranslate">
 print('Code block')
 </code>
-<pre>print('Pre block')
+<pre class="notranslate">print('Pre block')
 </pre>
 <h2 dir="auto">Horizontal rules</h2>
 <hr>
@@ -283,19 +283,19 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 </ul>
 <h2 dir="auto">Code</h2>
 <ul dir="auto">
-<li>Use the <code>printf()</code> function.</li>
-<li><code>There is a literal backtick (`) here.</code></li>
-<li>A single backtick in a code span: <code>`</code></li>
-<li>A backtick-delimited string in a code span: <code>`foo`</code></li>
-<li>Please don't use any <code>&lt;blink&gt;</code> tags.</li>
-<li><code>&amp;#8212;</code> is the decimal-encoded equivalent of <code>&amp;mdash;</code></li>
+<li>Use the <code class="notranslate">printf()</code> function.</li>
+<li><code class="notranslate">There is a literal backtick (`) here.</code></li>
+<li>A single backtick in a code span: <code class="notranslate">`</code></li>
+<li>A backtick-delimited string in a code span: <code class="notranslate">`foo`</code></li>
+<li>Please don't use any <code class="notranslate">&lt;blink&gt;</code> tags.</li>
+<li><code class="notranslate">&amp;#8212;</code> is the decimal-encoded equivalent of <code class="notranslate">&amp;mdash;</code></li>
 </ul>
 <h2 dir="auto">Images</h2>
 <ul dir="auto">
-<li><a target="_blank" rel="noopener noreferrer" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" style="max-width: 100%;"></a></li>
-<li><a target="_blank" rel="noopener noreferrer" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" title="Optional title" style="max-width: 100%;"></a></li>
-<li><a target="_blank" rel="noopener noreferrer" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" title="Optional title attribute" style="max-width: 100%;"></a></li>
-<li><a target="_blank" rel="noopener noreferrer" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" width="32" height="32" style="max-width: 100%;"></a>   ← bigger &amp; blurrier</li>
+<li><a target="_blank" rel="noopener noreferrer nofollow" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" style="max-width: 100%;"></a></li>
+<li><a target="_blank" rel="noopener noreferrer nofollow" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" title="Optional title" style="max-width: 100%;"></a></li>
+<li><a target="_blank" rel="noopener noreferrer nofollow" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" title="Optional title attribute" style="max-width: 100%;"></a></li>
+<li><a target="_blank" rel="noopener noreferrer nofollow" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" width="32" height="32" style="max-width: 100%; height: auto; max-height: 32px;"></a>   ← bigger &amp; blurrier</li>
 </ul>
 <h2 dir="auto">Automatic links</h2>
 <ul dir="auto">
@@ -329,19 +329,19 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <h4 dir="auto">Strikethrough</h4>
 <p dir="auto"><del>Mistaken text.</del></p>
 <h4 dir="auto">Fenced code blocks</h4>
-<pre><code>function test() {
+<pre class="notranslate"><code class="notranslate">function test() {
   console.log("notice the blank line before this function?");
 }
 </code></pre>
 <h4 dir="auto">Syntax highlighting</h4>
-<div class="highlight highlight-source-python"><pre><span class="pl-en">print</span>(<span class="pl-s">'Hello!'</span>)</pre></div>
-<div class="highlight highlight-source-js"><pre><span class="pl-smi">console</span><span class="pl-kos">.</span><span class="pl-en">log</span><span class="pl-kos">(</span><span class="pl-s">'JavaScript!'</span><span class="pl-kos">)</span><span class="pl-kos">;</span></pre></div>
-<div class="highlight highlight-source-js"><pre><span class="pl-smi">console</span><span class="pl-kos">.</span><span class="pl-en">log</span><span class="pl-kos">(</span><span class="pl-s">'JavaScript (with js)!'</span><span class="pl-kos">)</span><span class="pl-kos">;</span></pre></div>
-<pre lang="unmatched_language"><code>console.log('No matching language, but looks like JavaScript.');
+<div class="highlight highlight-source-python" dir="auto"><pre class="notranslate"><span class="pl-en">print</span>(<span class="pl-s">'Hello!'</span>)</pre></div>
+<div class="highlight highlight-source-js" dir="auto"><pre class="notranslate"><span class="pl-smi">console</span><span class="pl-kos">.</span><span class="pl-en">log</span><span class="pl-kos">(</span><span class="pl-s">'JavaScript!'</span><span class="pl-kos">)</span><span class="pl-kos">;</span></pre></div>
+<div class="highlight highlight-source-js" dir="auto"><pre class="notranslate"><span class="pl-smi">console</span><span class="pl-kos">.</span><span class="pl-en">log</span><span class="pl-kos">(</span><span class="pl-s">'JavaScript (with js)!'</span><span class="pl-kos">)</span><span class="pl-kos">;</span></pre></div>
+<pre lang="unmatched_language" class="notranslate"><code class="notranslate">console.log('No matching language, but looks like JavaScript.');
 </code></pre>
 <h4 dir="auto">Tables</h4>
 <p dir="auto">Simple:</p>
-<table role="table">
+<markdown-accessiblity-table><table role="table">
 <thead>
 <tr>
 <th>First Header</th>
@@ -358,9 +358,9 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <td>Content Cell</td>
 </tr>
 </tbody>
-</table>
+</table></markdown-accessiblity-table>
 <p dir="auto">Pipes:</p>
-<table role="table">
+<markdown-accessiblity-table><table role="table">
 <thead>
 <tr>
 <th>First Header</th>
@@ -377,9 +377,9 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <td>Content Cell</td>
 </tr>
 </tbody>
-</table>
+</table></markdown-accessiblity-table>
 <p dir="auto">Unmatched:</p>
-<table role="table">
+<markdown-accessiblity-table><table role="table">
 <thead>
 <tr>
 <th>Name</th>
@@ -396,9 +396,9 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <td>Closes a window</td>
 </tr>
 </tbody>
-</table>
+</table></markdown-accessiblity-table>
 <p dir="auto">Inner Markdown:</p>
-<table role="table">
+<markdown-accessiblity-table><table role="table">
 <thead>
 <tr>
 <th>Name</th>
@@ -415,9 +415,9 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <td><em>Closes</em> a window</td>
 </tr>
 </tbody>
-</table>
+</table></markdown-accessiblity-table>
 <p dir="auto">Alignment:</p>
-<table role="table">
+<markdown-accessiblity-table><table role="table">
 <thead>
 <tr>
 <th align="left">Left-Aligned</th>
@@ -447,7 +447,7 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <td align="right"></td>
 </tr>
 </tbody>
-</table>
+</table></markdown-accessiblity-table>
 <h4 dir="auto">HTML</h4>
 <p dir="auto"><em>TODO: Test all allowed HTML tags.</em></p>
 <h2 dir="auto">Writing on GitHub</h2>
@@ -457,21 +457,21 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 Violets are Blue</p>
 <h4 dir="auto">Task lists</h4>
 <ul class="contains-task-list">
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" checked=""> @mentions, #refs, <a href="">links</a>, <strong>formatting</strong>, and <del>tags</del> are supported</li>
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" checked=""> list syntax is required (any unordered or ordered list supported)</li>
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" checked=""> this is a complete item</li>
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox"> this is an incomplete item</li>
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Completed task" checked=""> @mentions, #refs, <a href="">links</a>, <strong>formatting</strong>, and <del>tags</del> are supported</li>
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Completed task" checked=""> list syntax is required (any unordered or ordered list supported)</li>
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Completed task" checked=""> this is a complete item</li>
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Incomplete task"> this is an incomplete item</li>
 </ul>
 <p dir="auto">Task lists can be nested to better structure your tasks:</p>
 <ul class="contains-task-list">
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox"> a bigger project
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Incomplete task"> a bigger project
 <ul class="contains-task-list">
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" checked=""> first subtask #1234</li>
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox"> follow up subtask #4321</li>
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox"> final subtask cc @mention</li>
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Completed task" checked=""> first subtask #1234</li>
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Incomplete task"> follow up subtask #4321</li>
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Incomplete task"> final subtask cc @mention</li>
 </ul>
 </li>
-<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" checked=""> a separate task</li>
+<li class="task-list-item"><input type="checkbox" id="" disabled="" class="task-list-item-checkbox" aria-label="Completed task" checked=""> a separate task</li>
 </ul>
 <h4 dir="auto">References</h4>
 <ul dir="auto">

--- a/tests/output/renderer/gfm-test.html
+++ b/tests/output/renderer/gfm-test.html
@@ -1,14 +1,12 @@
-<h1>
-<a id="user-content-github-flavored-markdown-test" class="anchor" href="#github-flavored-markdown-test" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>GitHub Flavored Markdown Test</h1>
+<div class="markdown-heading"><h1 class="heading-element">GitHub Flavored Markdown Test</h1><a id="user-content-github-flavored-markdown-test" class="anchor" aria-label="Permalink: GitHub Flavored Markdown Test" href="#github-flavored-markdown-test"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>This Markdown file contains all the features of <strong>GitHub Flavored Markdown</strong> for
 testing a renderer with.</p>
 <p>The features are taken directly from <a href="https://daringfireball.net/projects/markdown/syntax" rel="nofollow">Daring Fireball</a>
 and <a href="https://help.github.com/articles/github-flavored-markdown/">GitHub Flavored Markdown</a>,
 followed by a list of one-offs.</p>
-<h2>
-<a id="user-content-inline-html" class="anchor" href="#inline-html" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Inline HTML</h2>
+<div class="markdown-heading"><h2 class="heading-element">Inline HTML</h2><a id="user-content-inline-html" class="anchor" aria-label="Permalink: Inline HTML" href="#inline-html"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <table>
-  <tr>
+  <tbody><tr>
     <td>Foo</td>
   </tr>
   <tr>
@@ -17,13 +15,12 @@ followed by a list of one-offs.</p>
       E.g., you can’t use Markdown-style *emphasis* inside an HTML block.
     </td>
   </tr>
-</table>
+</tbody></table>
 <p>Span-level HTML tags — e.g. &lt;span&gt;, &lt;cite&gt;, or &lt;del&gt; — can be used anywhere
 in a Markdown paragraph, list item, or header. If you want, you can even use HTML tags instead
 of Markdown formatting; e.g. if you’d prefer to use HTML &lt;a&gt; or &lt;img&gt; tags instead
 of Markdown’s link or image syntax, go right ahead.</p>
-<h4>
-<a id="user-content-testing-span-cite-and-del-tags" class="anchor" href="#testing-span-cite-and-del-tags" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Testing <span>span</span>, cite, and <del>del</del> tags</h4>
+<div class="markdown-heading"><h4 class="heading-element">Testing <span>span</span>, cite, and <del>del</del> tags</h4><a id="user-content-testing-span-cite-and-del-tags" class="anchor" aria-label="Permalink: Testing span, cite, and del tags" href="#testing-span-cite-and-del-tags"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Testing <span>span</span>, cite, and <del>del</del> tags in a paragraph.</p>
 <p>And each element in its own list item:</p>
 <ul>
@@ -31,8 +28,7 @@ of Markdown’s link or image syntax, go right ahead.</p>
 <li>This is within a cite tag.</li>
 <li><del>This is within a del tag.</del></li>
 </ul>
-<h2>
-<a id="user-content-automatic-escaping-for-special-characters" class="anchor" href="#automatic-escaping-for-special-characters" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Automatic escaping for special characters</h2>
+<div class="markdown-heading"><h2 class="heading-element">Automatic escaping for special characters</h2><a id="user-content-automatic-escaping-for-special-characters" class="anchor" aria-label="Permalink: Automatic escaping for special characters" href="#automatic-escaping-for-special-characters"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ul>
 <li>© copyright</li>
 <li>AT&amp;T should render the same as AT&amp;T</li>
@@ -44,8 +40,7 @@ convert <code>&amp;amp;</code>. So these two should yield different links:</p>
 <li><a href="http://images.google.com/images?num=30&amp;q=larry+bird" rel="nofollow">http://images.google.com/images?num=30&amp;q=larry+bird</a></li>
 <li><a href="http://images.google.com/images?num=30&amp;amp;q=larry+bird" rel="nofollow">http://images.google.com/images?num=30&amp;amp;q=larry+bird</a></li>
 </ul>
-<h2>
-<a id="user-content-paragraphs-and-line-breaks" class="anchor" href="#paragraphs-and-line-breaks" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Paragraphs and line breaks</h2>
+<div class="markdown-heading"><h2 class="heading-element">Paragraphs and line breaks</h2><a id="user-content-paragraphs-and-line-breaks" class="anchor" aria-label="Permalink: Paragraphs and line breaks" href="#paragraphs-and-line-breaks"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>This is a normal paragraph.</p>
 <p>This and the next sentence is separated by a single newline.
 This should be on the same line.</p>
@@ -55,36 +50,26 @@ This should be on a new line, directly below.</p>
 This should be two lines below.</p>
 <p>These two paragraphs are separated by two <code>&lt;br /&gt;</code> tags. <br><br></p>
 <p>This should be three lines below.</p>
-<h2>
-<a id="user-content-headers" class="anchor" href="#headers" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Headers</h2>
+<div class="markdown-heading"><h2 class="heading-element">Headers</h2><a id="user-content-headers" class="anchor" aria-label="Permalink: Headers" href="#headers"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Here are some headers followed by <a href="https://en.wikipedia.org/wiki/Lorem_ipsum" rel="nofollow">Lorem Ipsum</a>.</p>
-<h1>
-<a id="user-content-this-is-an-h1-setext-style" class="anchor" href="#this-is-an-h1-setext-style" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>This is an H1 (Setext-style)</h1>
+<div class="markdown-heading"><h1 class="heading-element">This is an H1 (Setext-style)</h1><a id="user-content-this-is-an-h1-setext-style" class="anchor" aria-label="Permalink: This is an H1 (Setext-style)" href="#this-is-an-h1-setext-style"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-<h2>
-<a id="user-content-this-is-an-h2-setext-style" class="anchor" href="#this-is-an-h2-setext-style" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>This is an H2 (Setext-style)</h2>
+<div class="markdown-heading"><h2 class="heading-element">This is an H2 (Setext-style)</h2><a id="user-content-this-is-an-h2-setext-style" class="anchor" aria-label="Permalink: This is an H2 (Setext-style)" href="#this-is-an-h2-setext-style"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 <p>The following are atx-style.</p>
-<h1>
-<a id="user-content-this-is-an-h1" class="anchor" href="#this-is-an-h1" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>This is an H1</h1>
+<div class="markdown-heading"><h1 class="heading-element">This is an H1</h1><a id="user-content-this-is-an-h1" class="anchor" aria-label="Permalink: This is an H1" href="#this-is-an-h1"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-<h2>
-<a id="user-content-this-is-an-h2" class="anchor" href="#this-is-an-h2" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>This is an H2</h2>
+<div class="markdown-heading"><h2 class="heading-element">This is an H2</h2><a id="user-content-this-is-an-h2" class="anchor" aria-label="Permalink: This is an H2" href="#this-is-an-h2"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Mauris feugiat, augue vitae sollicitudin vulputate, neque arcu dapibus eros, eget semper lorem ex rhoncus nulla.</p>
-<h3>
-<a id="user-content-this-is-an-h3" class="anchor" href="#this-is-an-h3" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>This is an H3</h3>
+<div class="markdown-heading"><h3 class="heading-element">This is an H3</h3><a id="user-content-this-is-an-h3" class="anchor" aria-label="Permalink: This is an H3" href="#this-is-an-h3"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Etiam sit amet orci sit amet dui mollis molestie.</p>
-<h4>
-<a id="user-content-this-is-an-h4" class="anchor" href="#this-is-an-h4" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>This is an H4</h4>
+<div class="markdown-heading"><h4 class="heading-element">This is an H4</h4><a id="user-content-this-is-an-h4" class="anchor" aria-label="Permalink: This is an H4" href="#this-is-an-h4"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Cras et elit egestas, lacinia est eu, vestibulum enim.</p>
-<h5>
-<a id="user-content-this-is-an-h5" class="anchor" href="#this-is-an-h5" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>This is an H5</h5>
+<div class="markdown-heading"><h5 class="heading-element">This is an H5</h5><a id="user-content-this-is-an-h5" class="anchor" aria-label="Permalink: This is an H5" href="#this-is-an-h5"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Phasellus sed suscipit quam.</p>
-<h6>
-<a id="user-content-this-is-an-h36" class="anchor" href="#this-is-an-h36" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>This is an H√36</h6>
+<div class="markdown-heading"><h6 class="heading-element">This is an H√36</h6><a id="user-content-this-is-an-h36" class="anchor" aria-label="Permalink: This is an H√36" href="#this-is-an-h36"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Nam rutrum imperdiet purus, sit amet porttitor augue tempor quis.</p>
-<h2>
-<a id="user-content-blockquotes" class="anchor" href="#blockquotes" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Blockquotes</h2>
+<div class="markdown-heading"><h2 class="heading-element">Blockquotes</h2><a id="user-content-blockquotes" class="anchor" aria-label="Permalink: Blockquotes" href="#blockquotes"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Email-style blockquotes:</p>
 <blockquote>
 <p>This is a blockquote with two paragraphs. Lorem ipsum dolor sit amet,
@@ -113,8 +98,7 @@ id sem consectetuer libero luctus adipiscing.</p>
 </blockquote>
 <p>Blockquotes containing other Markdown elements:</p>
 <blockquote>
-<h2>
-<a id="user-content-this-is-a-header" class="anchor" href="#this-is-a-header" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>This is a header.</h2>
+<div class="markdown-heading"><h2 class="heading-element">This is a header.</h2><a id="user-content-this-is-a-header" class="anchor" aria-label="Permalink: This is a header." href="#this-is-a-header"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ol>
 <li>This is the first list item.</li>
 <li>This is the second list item.</li>
@@ -123,10 +107,8 @@ id sem consectetuer libero luctus adipiscing.</p>
 <pre><code>return shell_exec("echo $input | $markdown_script");
 </code></pre>
 </blockquote>
-<h2>
-<a id="user-content-lists" class="anchor" href="#lists" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Lists</h2>
-<h5>
-<a id="user-content-these-three-lists-should-be-equivalent" class="anchor" href="#these-three-lists-should-be-equivalent" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>These three lists should be equivalent</h5>
+<div class="markdown-heading"><h2 class="heading-element">Lists</h2><a id="user-content-lists" class="anchor" aria-label="Permalink: Lists" href="#lists"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
+<div class="markdown-heading"><h5 class="heading-element">These three lists should be equivalent</h5><a id="user-content-these-three-lists-should-be-equivalent" class="anchor" aria-label="Permalink: These three lists should be equivalent" href="#these-three-lists-should-be-equivalent"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>First:</p>
 <ul>
 <li>Red</li>
@@ -145,8 +127,7 @@ id sem consectetuer libero luctus adipiscing.</p>
 <li>Green</li>
 <li>Blue</li>
 </ul>
-<h4>
-<a id="user-content-these-three-ordered-lists-should-be-equivalent" class="anchor" href="#these-three-ordered-lists-should-be-equivalent" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>These three ordered lists should be equivalent</h4>
+<div class="markdown-heading"><h4 class="heading-element">These three ordered lists should be equivalent</h4><a id="user-content-these-three-ordered-lists-should-be-equivalent" class="anchor" aria-label="Permalink: These three ordered lists should be equivalent" href="#these-three-ordered-lists-should-be-equivalent"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>First:</p>
 <ol>
 <li>Bird</li>
@@ -165,8 +146,7 @@ id sem consectetuer libero luctus adipiscing.</p>
 <li>McHale</li>
 <li>Parish</li>
 </ol>
-<h4>
-<a id="user-content-these-two-lists-should-be-equivalent" class="anchor" href="#these-two-lists-should-be-equivalent" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>These two lists should be equivalent</h4>
+<div class="markdown-heading"><h4 class="heading-element">These two lists should be equivalent</h4><a id="user-content-these-two-lists-should-be-equivalent" class="anchor" aria-label="Permalink: These two lists should be equivalent" href="#these-two-lists-should-be-equivalent"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>First:</p>
 <ul>
 <li>Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
@@ -183,8 +163,7 @@ viverra nec, fringilla in, laoreet vitae, risus.</li>
 <li>Donec sit amet nisl. Aliquam semper ipsum sit amet velit.
 Suspendisse id sem consectetuer libero luctus adipiscing.</li>
 </ul>
-<h4>
-<a id="user-content-paragraphs-and-lists" class="anchor" href="#paragraphs-and-lists" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Paragraphs and lists</h4>
+<div class="markdown-heading"><h4 class="heading-element">Paragraphs and lists</h4><a id="user-content-paragraphs-and-lists" class="anchor" aria-label="Permalink: Paragraphs and lists" href="#paragraphs-and-lists"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ul>
 <li>Bird</li>
 <li>Magic</li>
@@ -198,8 +177,7 @@ Suspendisse id sem consectetuer libero luctus adipiscing.</li>
 <p>Magic</p>
 </li>
 </ul>
-<h4>
-<a id="user-content-paragraphs-within-lists" class="anchor" href="#paragraphs-within-lists" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Paragraphs within lists</h4>
+<div class="markdown-heading"><h4 class="heading-element">Paragraphs within lists</h4><a id="user-content-paragraphs-within-lists" class="anchor" aria-label="Permalink: Paragraphs within lists" href="#paragraphs-within-lists"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>First:</p>
 <ol>
 <li>
@@ -226,8 +204,7 @@ sit amet, consectetuer adipiscing elit.</p>
 <p>Another item in the same list.</p>
 </li>
 </ul>
-<h4>
-<a id="user-content-blockquote-within-a-list" class="anchor" href="#blockquote-within-a-list" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Blockquote within a list</h4>
+<div class="markdown-heading"><h4 class="heading-element">Blockquote within a list</h4><a id="user-content-blockquote-within-a-list" class="anchor" aria-label="Permalink: Blockquote within a list" href="#blockquote-within-a-list"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ul>
 <li>
 <p>A list item with a blockquote:</p>
@@ -237,8 +214,7 @@ inside a list item.</p>
 </blockquote>
 </li>
 </ul>
-<h4>
-<a id="user-content-code-within-a-list" class="anchor" href="#code-within-a-list" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Code within a list</h4>
+<div class="markdown-heading"><h4 class="heading-element">Code within a list</h4><a id="user-content-code-within-a-list" class="anchor" aria-label="Permalink: Code within a list" href="#code-within-a-list"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ul>
 <li>
 <p>A list item with a code block:</p>
@@ -246,14 +222,12 @@ inside a list item.</p>
 </code></pre>
 </li>
 </ul>
-<h4>
-<a id="user-content-accidental-lists" class="anchor" href="#accidental-lists" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Accidental lists</h4>
+<div class="markdown-heading"><h4 class="heading-element">Accidental lists</h4><a id="user-content-accidental-lists" class="anchor" aria-label="Permalink: Accidental lists" href="#accidental-lists"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ol start="1986">
 <li>What a great season. (oops, I wanted a year, not a list)</li>
 </ol>
 <p>1986. What a great season. (<em>whew!</em> there we go)</p>
-<h2>
-<a id="user-content-code-blocks" class="anchor" href="#code-blocks" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Code blocks</h2>
+<div class="markdown-heading"><h2 class="heading-element">Code blocks</h2><a id="user-content-code-blocks" class="anchor" aria-label="Permalink: Code blocks" href="#code-blocks"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>This is a normal paragraph:</p>
 <pre><code>This is a code block.
 </code></pre>
@@ -275,18 +249,15 @@ end
 <code>
 print('Code block')
 </code>
-<pre>
-print('Pre block')
+<pre>print('Pre block')
 </pre>
-<h2>
-<a id="user-content-horizontal-rules" class="anchor" href="#horizontal-rules" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Horizontal rules</h2>
+<div class="markdown-heading"><h2 class="heading-element">Horizontal rules</h2><a id="user-content-horizontal-rules" class="anchor" aria-label="Permalink: Horizontal rules" href="#horizontal-rules"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <hr>
 <hr>
 <hr>
 <hr>
 <hr>
-<h2>
-<a id="user-content-links" class="anchor" href="#links" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Links</h2>
+<div class="markdown-heading"><h2 class="heading-element">Links</h2><a id="user-content-links" class="anchor" aria-label="Permalink: Links" href="#links"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Markdown supports two style of links: inline and reference.</p>
 <p>This is <a href="http://joeyespo.com/" title="Title" rel="nofollow">an example</a> inline link.</p>
 <p><a href="http://joeyespo.com/" rel="nofollow">This link</a> has no title attribute.</p>
@@ -301,8 +272,7 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <li><a href="http://joeyespo.com/" title="Optional Title Here" rel="nofollow">foo 4</a></li>
 <li><a href="http://joeyespo.com/" title="Optional Title Here" rel="nofollow">foo 5</a></li>
 </ul>
-<h2>
-<a id="user-content-emphasis" class="anchor" href="#emphasis" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Emphasis</h2>
+<div class="markdown-heading"><h2 class="heading-element">Emphasis</h2><a id="user-content-emphasis" class="anchor" aria-label="Permalink: Emphasis" href="#emphasis"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ul>
 <li><em>single asterisks</em></li>
 <li><em>single underscores</em></li>
@@ -311,8 +281,7 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <li>un<em>frigging</em>believable</li>
 <li>*this text is surrounded by literal asterisks*</li>
 </ul>
-<h2>
-<a id="user-content-code" class="anchor" href="#code" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Code</h2>
+<div class="markdown-heading"><h2 class="heading-element">Code</h2><a id="user-content-code" class="anchor" aria-label="Permalink: Code" href="#code"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ul>
 <li>Use the <code>printf()</code> function.</li>
 <li><code>There is a literal backtick (`) here.</code></li>
@@ -325,23 +294,20 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <code>&amp;#8212;</code> is the decimal-encoded equivalent of <code>&amp;mdash;</code>
 </li>
 </ul>
-<h2>
-<a id="user-content-images" class="anchor" href="#images" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Images</h2>
+<div class="markdown-heading"><h2 class="heading-element">Images</h2><a id="user-content-images" class="anchor" aria-label="Permalink: Images" href="#images"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ul>
-<li><a href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" target="_blank" rel="nofollow"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" style="max-width:100%;"></a></li>
-<li><a href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" target="_blank" rel="nofollow"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" title="Optional title" style="max-width:100%;"></a></li>
-<li><a href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" target="_blank" rel="nofollow"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" title="Optional title attribute" style="max-width:100%;"></a></li>
+<li><a target="_blank" rel="noopener noreferrer nofollow" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" style="max-width: 100%;"></a></li>
+<li><a target="_blank" rel="noopener noreferrer nofollow" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" title="Optional title" style="max-width: 100%;"></a></li>
+<li><a target="_blank" rel="noopener noreferrer nofollow" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" alt="Alt text" title="Optional title attribute" style="max-width: 100%;"></a></li>
 <li>
-<a href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" target="_blank" rel="nofollow"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" width="32" height="32" style="max-width:100%;"></a>   ← bigger &amp; blurrier</li>
+<a target="_blank" rel="noopener noreferrer nofollow" href="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico"><img src="https://raw.githubusercontent.com/joeyespo/grip/master/artwork/favicon.ico" width="32" height="32" style="max-width: 100%; height: auto; max-height: 32px;"></a>   ← bigger &amp; blurrier</li>
 </ul>
-<h2>
-<a id="user-content-automatic-links" class="anchor" href="#automatic-links" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Automatic links</h2>
+<div class="markdown-heading"><h2 class="heading-element">Automatic links</h2><a id="user-content-automatic-links" class="anchor" aria-label="Permalink: Automatic links" href="#automatic-links"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ul>
 <li><a href="http://joeyespo.com/" rel="nofollow">http://joeyespo.com/</a></li>
 <li><a href="mailto:joe@joeyespo.com">joe@joeyespo.com</a></li>
 </ul>
-<h2>
-<a id="user-content-backslash-escapes" class="anchor" href="#backslash-escapes" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Backslash escapes</h2>
+<div class="markdown-heading"><h2 class="heading-element">Backslash escapes</h2><a id="user-content-backslash-escapes" class="anchor" aria-label="Permalink: Backslash escapes" href="#backslash-escapes"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ul>
 <li>*literal asterisks*</li>
 <li>\   backslash</li>
@@ -357,35 +323,28 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 <li>.   dot</li>
 <li>!   exclamation mark</li>
 </ul>
-<h2>
-<a id="user-content-github-flavored-markdown" class="anchor" href="#github-flavored-markdown" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>GitHub Flavored Markdown</h2>
+<div class="markdown-heading"><h2 class="heading-element">GitHub Flavored Markdown</h2><a id="user-content-github-flavored-markdown" class="anchor" aria-label="Permalink: GitHub Flavored Markdown" href="#github-flavored-markdown"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>See <a href="https://help.github.com/articles/github-flavored-markdown/">GitHub Flavored Markdown</a> for details.</p>
-<h4>
-<a id="user-content-multiple-underscores-in-words" class="anchor" href="#multiple-underscores-in-words" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Multiple underscores in words</h4>
+<div class="markdown-heading"><h4 class="heading-element">Multiple underscores in words</h4><a id="user-content-multiple-underscores-in-words" class="anchor" aria-label="Permalink: Multiple underscores in words" href="#multiple-underscores-in-words"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ul>
 <li>wow_great_stuff</li>
 </ul>
-<h4>
-<a id="user-content-url-autolinking" class="anchor" href="#url-autolinking" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>URL autolinking</h4>
+<div class="markdown-heading"><h4 class="heading-element">URL autolinking</h4><a id="user-content-url-autolinking" class="anchor" aria-label="Permalink: URL autolinking" href="#url-autolinking"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p><a href="http://joeyespo.com" rel="nofollow">http://joeyespo.com</a></p>
-<h4>
-<a id="user-content-strikethrough" class="anchor" href="#strikethrough" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Strikethrough</h4>
+<div class="markdown-heading"><h4 class="heading-element">Strikethrough</h4><a id="user-content-strikethrough" class="anchor" aria-label="Permalink: Strikethrough" href="#strikethrough"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p><del>Mistaken text.</del></p>
-<h4>
-<a id="user-content-fenced-code-blocks" class="anchor" href="#fenced-code-blocks" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Fenced code blocks</h4>
+<div class="markdown-heading"><h4 class="heading-element">Fenced code blocks</h4><a id="user-content-fenced-code-blocks" class="anchor" aria-label="Permalink: Fenced code blocks" href="#fenced-code-blocks"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <pre><code>function test() {
   console.log("notice the blank line before this function?");
 }
 </code></pre>
-<h4>
-<a id="user-content-syntax-highlighting" class="anchor" href="#syntax-highlighting" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Syntax highlighting</h4>
+<div class="markdown-heading"><h4 class="heading-element">Syntax highlighting</h4><a id="user-content-syntax-highlighting" class="anchor" aria-label="Permalink: Syntax highlighting" href="#syntax-highlighting"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <div class="highlight highlight-source-python"><pre><span class="pl-en">print</span>(<span class="pl-s">'Hello!'</span>)</pre></div>
 <div class="highlight highlight-source-js"><pre><span class="pl-smi">console</span><span class="pl-kos">.</span><span class="pl-en">log</span><span class="pl-kos">(</span><span class="pl-s">'JavaScript!'</span><span class="pl-kos">)</span><span class="pl-kos">;</span></pre></div>
 <div class="highlight highlight-source-js"><pre><span class="pl-smi">console</span><span class="pl-kos">.</span><span class="pl-en">log</span><span class="pl-kos">(</span><span class="pl-s">'JavaScript (with js)!'</span><span class="pl-kos">)</span><span class="pl-kos">;</span></pre></div>
 <pre lang="unmatched_language"><code>console.log('No matching language, but looks like JavaScript.');
 </code></pre>
-<h4>
-<a id="user-content-tables" class="anchor" href="#tables" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Tables</h4>
+<div class="markdown-heading"><h4 class="heading-element">Tables</h4><a id="user-content-tables" class="anchor" aria-label="Permalink: Tables" href="#tables"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Simple:</p>
 <table>
 <thead>
@@ -496,18 +455,14 @@ This is [an example] <a href="http://joeyespo.com/" title="Optional Title Here" 
 </tr>
 </tbody>
 </table>
-<h4>
-<a id="user-content-html" class="anchor" href="#html" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>HTML</h4>
+<div class="markdown-heading"><h4 class="heading-element">HTML</h4><a id="user-content-html" class="anchor" aria-label="Permalink: HTML" href="#html"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p><em>TODO: Test all allowed HTML tags.</em></p>
-<h2>
-<a id="user-content-writing-on-github" class="anchor" href="#writing-on-github" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Writing on GitHub</h2>
+<div class="markdown-heading"><h2 class="heading-element">Writing on GitHub</h2><a id="user-content-writing-on-github" class="anchor" aria-label="Permalink: Writing on GitHub" href="#writing-on-github"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>See <a href="https://help.github.com/articles/writing-on-github/">this article</a> for details.</p>
-<h4>
-<a id="user-content-newlines" class="anchor" href="#newlines" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Newlines</h4>
+<div class="markdown-heading"><h4 class="heading-element">Newlines</h4><a id="user-content-newlines" class="anchor" aria-label="Permalink: Newlines" href="#newlines"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>Roses are red
 Violets are Blue</p>
-<h4>
-<a id="user-content-task-lists" class="anchor" href="#task-lists" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Task lists</h4>
+<div class="markdown-heading"><h4 class="heading-element">Task lists</h4><a id="user-content-task-lists" class="anchor" aria-label="Permalink: Task lists" href="#task-lists"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ul>
 <li class="task-list-item"><input type="checkbox" class="task-list-item-checkbox" checked="" disabled=""> @mentions, #refs, <a href="">links</a>, <strong>formatting</strong>, and <del>tags</del> are supported</li>
 <li class="task-list-item"><input type="checkbox" class="task-list-item-checkbox" checked="" disabled=""> list syntax is required (any unordered or ordered list supported)</li>
@@ -525,8 +480,7 @@ Violets are Blue</p>
 </li>
 <li class="task-list-item"><input type="checkbox" class="task-list-item-checkbox" checked="" disabled=""> a separate task</li>
 </ul>
-<h4>
-<a id="user-content-references" class="anchor" href="#references" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>References</h4>
+<div class="markdown-heading"><h4 class="heading-element">References</h4><a id="user-content-references" class="anchor" aria-label="Permalink: References" href="#references"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <ul>
 <li>SHA: dbcd7a410ee7489acf92f40641a135fbcf52a768</li>
 <li>User@SHA: joeyespo@dbcd7a410ee7489acf92f40641a135fbcf52a768</li>

--- a/tests/output/renderer/simple.html
+++ b/tests/output/renderer/simple.html
@@ -1,3 +1,2 @@
-<h1>
-<a id="user-content-simple-test-" class="anchor" href="#simple-test-" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Simple Test ✓</h1>
+<div class="markdown-heading"><h1 class="heading-element">Simple Test ✓</h1><a id="user-content-simple-test-" class="anchor" aria-label="Permalink: Simple Test ✓" href="#simple-test-"><span aria-hidden="true" class="octicon octicon-link"></span></a></div>
 <p>This is just a simple Unicode Markdown test.</p>

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -74,7 +74,7 @@ def test_styles_exist(tmpdir):
     files = list(map(lambda f: os.path.basename(str(f)), tmpdir.listdir()))
     assert any(f.startswith('github-') and f.endswith('.css') for f in files)
     assert any(
-        f.startswith('frameworks-') and f.endswith('.css') for f in files)
+        f.startswith('primer-') and f.endswith('.css') for f in files)
 
     # TODO: Test that style retrieval actually parsed CSS with regex
 


### PR DESCRIPTION
Looks like your unit tests depend on exact HTML coming from Github.   Now it's Aug 2025,  and the tests are failing because there were no updates to this project for a while.

Here is the patch for these tests.